### PR TITLE
First draft of scraper.py

### DIFF
--- a/househunt.yaml
+++ b/househunt.yaml
@@ -1,0 +1,15 @@
+name: 'househunt'
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - lxml
+  - pip
+  - scipy
+  - pandas
+  - docopt
+  - pip:
+    - beautifulsoup4
+
+

--- a/pyhousehunter/scraper.py
+++ b/pyhousehunter/scraper.py
@@ -1,0 +1,7 @@
+from urllib.request import Request, urlopen
+from bs4 import BeautifulSoup
+
+# scraping
+url = 'https://vancouver.craigslist.org/search/van/apa'
+
+print(url)

--- a/pyhousehunter/scraper.py
+++ b/pyhousehunter/scraper.py
@@ -1,75 +1,63 @@
 # author: Alex Truong Hai Yen
 # date: 2021-02-25
 
-"""""Scrape housing data from a give craiglist url and export result to csv file.
-
-Usage: pyhousehunter/scraper.py --url=<url> 
-
-Options:
---url=<url>              The chosen craiglist url 
-"""
-
 from bs4 import BeautifulSoup
 import requests
 import pandas as pd
 import csv
-from docopt import docopt
-
-opt = docopt(__doc__)
-
-
-### PART1: create soup object from the url
-def make_soup(url):
+ 
+def scraper(url, online = False, save_csv = False):
     """Function to scrape housing data from a given craiglist url
 
     Parameters
     ----------
     url : url
-        The given craiglist url
-
-    Returns
-    -------
-    bs4.BeautifulSoup
-        The soup object from scraping the url
-    """
-    headers = {
-        'DNT': '1',
-        'Referer': 'https://vancouver.craigslist.org/',
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
-    }
-
-    page = requests.get(url, headers = headers)
-
-    # checking scrape status
-    if page.status_code == 200:
-        print("OK")
-    else: 
-        print(page.status_code)
-
-    soup = BeautifulSoup(page.text, 'html.parser')
+        The given craiglist url to scrape the data from
     
-    return soup
+    online: bool
+        Whether the data is scraped directly online from the url (default = False) 
+        False means the data is scraped from local HTML file
 
-
-### PART2: extracting information from scrape results and export to csv
-def extractor(soup): 
-    """Extract information from the soup object and export result to csv
-
-    Parameters
-    ----------
-    soup : bs4.BeautifulSoup
-        The soup object from scraping the url
+    save_csv: bool
+        Whether to export the data to CSV file (default = False)
 
     Returns
     -------
-        a csv file contained listing information such as price, house type and neighborhood
+    pandas.core.frame.DataFrame
+        A dataframe containing listing information such as price, house type and neighborhood. 
+        A csv containing the dataframe could also be exported with `save_csv` option is 
+        activated to True.
 
+    Examples
+    -------
+    >>> scraper(url = 'https://vancouver.craigslist.org/search/van/apa', save_csv = True)
     """
-       
+
+    # PART 1: create soup object either from the url or local HTML file
+    if online:
+        headers = {
+            'DNT': '1',
+            'Referer': 'https://vancouver.craigslist.org/',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+        }
+
+        page = requests.get(url, headers = headers)
+
+        # checking scrape status
+        if page.status_code == 200:
+            print("OK")
+        else: 
+            print(page.status_code)
+
+        soup = BeautifulSoup(page.text, 'html.parser')
+    else:
+        soup = BeautifulSoup(open("pyhousehunter/temp/van_housing_listings.html"), "html.parser") # local scraping
+
+
+    # PART2: extracting information from scrape results into dataframe
     listings = soup.find_all('div', attrs = {'class': 'result-info'})
     data = []
 
-    # extract data from soup object
     for i in range(len(listings)):
         listing_id = listings[i].find('a').get('data-id')
         listing_url = listings[i].find('a').get('href')
@@ -78,22 +66,15 @@ def extractor(soup):
         neighborhood = listings[i].find('span', attrs = {'class': 'result-hood'})
 
         data.append((listing_id, listing_url, price, house, neighborhood))
+
+    output = pd.DataFrame(
+        data,
+        columns = ['listing_id', 'listing_url', 'price', 'house_type', 'neighborhood']
+    )
     
-    # writing results to CSV file
-    with open('raw.csv', 'w', newline='') as csv_file:
-        writer = csv.writer(csv_file)
-        for listing_id, listing_url, price, house, neighborhood in data:
-            writer.writerow([listing_id, listing_url, price, house, neighborhood])
 
+    # PART3: activate the option to write results to CSV file
+    if save_csv:
+        output.to_csv('raw.csv', index_label = "serial_no")
 
-### PART3: the main function      
-def main(url):
-    soup = BeautifulSoup(open("pyhousehunter/temp/van_housing_listings.html"), "html.parser") # local scraping
-    #soup = make_soup(url) # online scraping
-    data = extractor(soup)
-
-
-if __name__ == "__main__":
-  main(opt["--url"])
-  
-
+    return output

--- a/pyhousehunter/scraper.py
+++ b/pyhousehunter/scraper.py
@@ -1,7 +1,60 @@
-from urllib.request import Request, urlopen
 from bs4 import BeautifulSoup
+import requests
+import pandas as pd
+import csv
 
-# scraping
-url = 'https://vancouver.craigslist.org/search/van/apa'
+### PART1: scraping directly from the web
+url = 'https://vancouver.craigslist.org/search/van/apa' 
 
-print(url)
+def online_scraper(url):
+    headers = {
+        'DNT': '1',
+        'Referer': 'https://vancouver.craigslist.org/',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+    }
+
+    page = requests.get(url, headers = headers)
+
+    # checking scrape status
+    if page.status_code == 200:
+        print("OK")
+    else: 
+        print(page.status_code)
+
+    soup = BeautifulSoup(page.text, 'html.parser')
+    
+    return soup
+
+
+
+### PART2: extracting information from scrape results
+
+#soup = online_scraper(url) # online scraping
+soup = BeautifulSoup(open("../van_housing_listings.html"), "html.parser") # local scraping
+listings = soup.find_all('div', attrs = {'class': 'result-info'})
+data = []
+
+for i in range(len(listings)):
+    listing_id = listings[i].find('a').get('data-id')
+    listing_url = listings[i].find('a').get('href')
+    price= listings[i].find('span', attrs = {'class': 'result-price'}).text
+    house = listings[i].find('span', attrs = {'class': 'housing'})
+    neighborhood = listings[i].find('span', attrs = {'class': 'result-hood'})
+
+    data.append((listing_id, listing_url, price, house, neighborhood))
+
+
+### PART2B: preprocessing (to be abstracted to another scrip and work directly with csv)
+
+# price
+#processed_price = int("".join(price.split('$')[1].split(',')))
+#print(processed_price+1) # test for numeric output
+
+
+### PART3: writing results to CSV file
+
+with open('raw.csv', 'w', newline='') as csv_file:
+    writer = csv.writer(csv_file)
+    for listing_id, listing_url, price, house, neighborhood in data:
+        writer.writerow([listing_id, listing_url, price, house, neighborhood])
+

--- a/pyhousehunter/temp/van_housing_listings.html
+++ b/pyhousehunter/temp/van_housing_listings.html
@@ -1,0 +1,6499 @@
+<!DOCTYPE html>
+<!-- saved from url=(0073)https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa -->
+<html class="js canvas draggable fileAPI geolocation matchMedia picture pushState placeholder no-touchCapable transitions"><link type="text/css" rel="stylesheet" id="dark-mode-custom-link"><link type="text/css" rel="stylesheet" id="dark-mode-general-link"><style lang="en" type="text/css" id="dark-mode-custom-style"></style><style lang="en" type="text/css" id="dark-mode-native-style"></style><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>vancouver, BC apartments / housing for rent   - craigslist</title>
+    <script type="application/ld+json" id="ld_breadcrumb_data">
+    {"@context":"https://schema.org","itemListElement":[{"item":{"name":"vancouver.craigslist.org","@id":"https://vancouver.craigslist.org"},"position":1,"@type":"ListItem"},{"item":{"name":"housing","@id":"https://vancouver.craigslist.org/d/housing/search/hhh"},"position":2,"@type":"ListItem"},{"item":{"name":"apartments / housing for rent","@id":"https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa"},"position":3,"@type":"ListItem"}],"@type":"BreadcrumbList"}
+</script>
+
+
+    <meta name="description" content="">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+        <link rel="canonical" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa">
+        <link rel="next" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?s=120">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/cl.css">
+    <link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/search.css">
+    <link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/jquery-ui-clcustom.css">
+<link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/leaflet.css">
+<link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/MarkerCluster.css">
+<link type="text/css" rel="stylesheet" media="all" href="./vancouver, BC apartments _ housing for rent - craigslist_files/tocsmaps.css">
+<!--[if IE]>
+    <link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/tocsmaps-ie.css?v=6bcbe5817e70c9a7f673ff72ba3e56e5">
+<![endif]-->
+
+    
+        <script type="text/javascript"><!--
+var areaCountry = "CA";
+var areaID = "16";
+var areaRegion = "BC";
+var catAbb = "apa";
+var countOfTotalText = "image {count} of {total}";
+var currencySymbol = "&#x0024;";
+var defaultView = "grid";
+var expiredFavIDs = null;
+var imageConfig = {"1":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"4":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"0":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450"]},"3":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"2":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]}};
+var lessInfoText = "less info";
+var maptileBaseUrl = "//map{s}.craigslist.org/t09/{z}/{x}/{y}.png";
+var maxResults = 3000;
+var noImageText = "no image";
+var pID = null;
+var postalLat = null;
+var postalLon = null;
+var purveyorCategories = null;
+var searchDistance = null;
+var sectionAbb = "hhh";
+var sectionBase = "hhh";
+var showInfoText = "show info";
+var showMapTabs = 1;
+var showingBanished = 0;
+var showingFavorites = 0;
+var starHint = "save this post in your favorites list";
+var subarea = null;
+var zoomToPosting = null;
+--></script>
+    
+</head>
+<body class="search has-map desktop grid has-map-view-button" style="">
+    <script type="text/javascript"><!--
+    function C(k){return(document.cookie.match('(^|; )'+k+'=([^;]*)')||0)[2]}
+    var pagetype, pagemode;
+    (function(){
+        var h = document.documentElement;
+        h.className = h.className.replace('no-js', 'js');
+        var b = document.body;
+        var bodyClassList = b.className.split(/\s+/);;
+        pagetype = bodyClassList[0]; // dangerous assumption
+        var fmt = C('cl_fmt');
+        if ( fmt === 'regular' || fmt === 'mobile' ) {
+            pagemode = fmt;
+        } else if (screen.width <= 480) {
+            pagemode = 'mobile';
+        } else {
+            pagemode = 'regular';
+        }
+        pagemode = pagemode === 'mobile' ? 'mobile' : 'desktop';
+        bodyClassList.push(pagemode);
+        if (C('hidesearch') === '1' && pagemode !== 'mobile') {
+            bodyClassList.push('hide-search');
+        }
+        var width = window.innerWidth || document.documentElement.clientWidth;
+        if (width > 1000) { bodyClassList.push('w1024'); }
+        if (typeof window.sectionBase !== 'undefined') {
+            var mode = (decodeURIComponent(C('cl_tocmode') || '').match(new RegExp(window.sectionBase + ':([^,]+)', 'i')) || {})[1] || window.defaultView;
+            if (mode) {
+                bodyClassList.push(mode);
+            }
+        }
+        b.className = bodyClassList.join(' ');
+    }());
+--></script>
+
+
+    <section class="page-container" id="page-top">
+        <div class="bglogo"></div>
+        <div class="tryapp">
+    try the craigslist app »
+    <a class="appstorebtn" href="https://play.google.com/store/apps/details?id=org.craigslist.CraigslistMobile">
+        Android
+    </a>
+    <a class="appstorebtn" href="https://apps.apple.com/us/app/craigslist/id1336642410">
+        iOS
+    </a>
+</div>
+<header class="global-header wide">
+   <a class="header-logo" name="logoLink" href="https://vancouver.craigslist.org/">CL</a>
+
+    <nav class="breadcrumbs-container">
+<form id="breadcrumbform" class="breadcrumbs-form" method="get" action="https://vancouver.craigslist.org/search/apa" data-action="/search/###/apa">
+    
+    <ul class="breadcrumbs ">
+        <li class="crumb area">
+            
+            <span class="no-js">
+                <a href="https://vancouver.craigslist.org/">vancouver, BC</a>
+            </span>
+                <select id="areaAbb" class="js-only">
+                    <option value="vancouver">vancouver, BC</option>
+                        <option value="comoxvalley">comox valley</option>
+                        <option value="abbotsford">fraser valley</option>
+                        <option value="kamloops">kamloops</option>
+                        <option value="kelowna">kelowna</option>
+                        <option value="nanaimo">nanaimo</option>
+                        <option value="sunshine">sunshine coast</option>
+                        <option value="victoria">victoria, BC</option>
+                        <option value="whistler">whistler / squamish</option>
+                </select>
+            <span class="breadcrumb-arrow">&gt;</span>
+        </li>
+        <li class="crumb subarea">
+            <select id="subArea">
+                <option value="" selected="">all vancouver, BC</option>
+                <option value="bnc">burnaby/newwest</option>
+                <option value="rds">delta/surrey/langley</option>
+                <option value="nvn">north shore</option>
+                <option value="rch">richmond</option>
+                <option value="pml">tricities/pitt/maple</option>
+                <option value="van">vancouver</option>
+            </select>
+            <span class="breadcrumb-arrow">&gt;</span>
+        </li>
+        <li class="crumb section">
+                    <select id="catAbb">
+                        <option value="ccc">community</option>
+                        <option value="eee">events</option>
+                        <option value="sss">for sale</option>
+                        <option value="ggg">gigs</option>
+                        <option value="hhh" selected="">housing</option>
+                        <option value="jjj">jobs</option>
+                        <option value="rrr">resumes</option>
+                        <option value="bbb">services</option>
+                    </select>
+                <span class="breadcrumb-arrow">&gt;</span>
+        </li>
+        <li class="crumb category">
+            <select id="subcatAbb" class="js-only">
+                <option value="hhh">all</option>
+                    <option value="apa" selected="">apartments / housing for rent</option>
+                    <option value="swp">housing swap</option>
+                    <option value="off">office &amp; commercial</option>
+                    <option value="prk">parking &amp; storage</option>
+                    <option value="reb">real estate - by broker</option>
+                    <option value="reo">real estate - by owner</option>
+                    <option value="roo">rooms &amp; shares</option>
+                    <option value="sub">sublets &amp; temporary</option>
+                    <option value="vac">vacation rentals</option>
+                    <option value="hou">wanted: apts</option>
+                    <option value="rew">wanted: real estate</option>
+                    <option value="sha">wanted: room/share</option>
+                    <option value="sbw">wanted: sublet/temp</option>
+            </select><span class="no-js">apartments / housing for rent</span>
+            <span class="breadcrumb-arrow">&gt;</span>
+        </li>
+        <li class="crumb no-js">
+            <input type="submit" value="go">
+        </li>
+    </ul>
+</form>
+    </nav>
+
+<div class="userlinks">
+    <ul class="user-actions">
+        <li class="user post">
+            <a href="https://post.craigslist.org/c/van">post</a>
+        </li>
+        <li class="user account">
+            <a href="https://accounts.craigslist.org/login/home">account</a>
+        </li>
+    </ul>
+    <ul class="user-favs-discards">
+        <li class="user">
+            <div class="favorites off">
+                <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="favlink"><span class="icon icon-star fav" aria-hidden="true"></span><span class="fav-number">0</span><span class="fav-label"> favorites</span></a>
+            </div>
+        </li>
+        <li class="user discards">
+            <form class="unfavform js-only" method="GET" action="https://vancouver.craigslist.org/favorites">
+              <div class="to-banish-page">
+                <input type="hidden" class="unfaves" name="fl">
+                <input type="hidden" name="uf" value="1">
+                <a href="https://vancouver.craigslist.org/favorites?uf=1&amp;fl=aXRlbXM6" class="to-banish-page-link">
+                  <span class="icon icon-trash red" aria-hidden="true"></span>
+                  <span class="banished_count">0</span>
+                  <span class="discards-label"> hidden</span>
+                </a>
+              </div>
+          </form>
+        </li>
+    </ul>
+</div>
+
+</header>
+<header class="global-header narrow">
+   <a class="header-logo" href="https://vancouver.craigslist.org/">CL</a>
+    <nav class="breadcrumbs-container">
+
+<h1 class="breadcrumbs">
+
+vancouver, BC            &gt;
+
+apartments / housing for rent</h1>
+
+
+    </nav>
+    <span class="linklike show-wide-header">...</span>
+</header>
+
+
+        <form id="searchform" class="search-form" action="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa">
+            <div class="querybox">
+                <div class="form-tab js-only"><span class="search-open" title="hide search">«</span><span class="search-closed" title="show search">»</span></div>
+                <input type="text" placeholder="search apartments / housing for rent" name="query" id="query" value="" autocorrect="off" class="flatinput ui-autocomplete-input" autocapitalize="off" autocomplete="off" data-autocomplete="search">
+
+                <button type="submit" class="searchbtn">
+                    <span class="icon icon-search" aria-hidden="true"></span>
+                    <span class="screen-reader-text">press to search craigslist</span>
+                </button>
+                    <div class="savealert">
+                        <a class="saveme" data-action="save" href="https://accounts.craigslist.org/savesearch/save?URL=https%3A%2F%2Fvancouver%2Ecraigslist%2Eorg%2Fd%2Fapartments%2Dhousing%2Dfor%2Drent%2Fsearch%2Fapa" title="save this search">save search</a>
+                    </div>
+            </div>
+
+            <div class="search-options-container">
+    <h1 class="cattitle">
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" title="clear all search parameters" class="reset">apartments / housing for rent</a>
+    </h1>
+    <div class="search-options-header linklike">
+        <div class="icon icon-toggle-gear" aria-hidden="true"></div>
+        options<span class="options-close">close</span>
+    </div>
+    <input id="excats" type="hidden" name="excats">
+    <div class="search-options">
+        <div class="searchgroup categories">
+        </div>
+        <input type="hidden" name="userid" value="">
+
+
+
+
+
+        <div class="searchgroup" id="basic-bools">
+            <ul>
+    <li>
+       <label class="srchType">
+           <input type="checkbox" name="srchType" class="" value="T">
+           search titles only
+       </label>
+    </li>
+    <li>
+       <label class="hasPic">
+           <input type="checkbox" name="hasPic" class="autosubmit" value="1">
+           has image
+       </label>
+    </li>
+    <li>
+       <label class="postedToday">
+           <input type="checkbox" name="postedToday" class="autosubmit" value="1">
+           posted today
+       </label>
+    </li>
+    <li>
+       <label class="bundleDuplicates">
+           <input type="checkbox" name="bundleDuplicates" class="autosubmit" value="1">
+           bundle duplicates
+       </label>
+    </li>
+    <li>
+       <label class="searchNearby">
+           <input type="checkbox" name="searchNearby" class="" value="1">
+           include nearby areas
+       </label>
+    </li>
+</ul>
+
+                <ul class="js-only nearbyAreas ">
+                        <li class="nearbyZone nearbyZone_1">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_8" value="621" disabled="disabled">
+                            cariboo, BC <small>(cbo)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_5" value="473" disabled="disabled">
+                            comox valley, BC <small>(cmx)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_1" value="471" disabled="disabled">
+                            fraser valley, BC <small>(abb)</small>
+                        </label>
+                        </li>
+                        <li class="nearbyZone nearbyZone_1">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_6" value="381" disabled="disabled">
+                            kamloops, BC <small>(kml)</small>
+                        </label>
+                        </li>
+                        <li class="nearbyZone nearbyZone_1">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_7" value="380" disabled="disabled">
+                            kelowna / okanagan <small>(kel)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_0" value="382" disabled="disabled">
+                            nanaimo, BC <small>(nmo)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_3" value="622" disabled="disabled">
+                            sunshine coast, BC <small>(sun)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_2" value="177" disabled="disabled">
+                            victoria, BC <small>(vic)</small>
+                        </label>
+                        </li>
+                        <li class="">
+                        <label class="nearby">
+                            <input type="checkbox" class="use-id nearbyArea" name="nearbyArea" id="nearbyArea_4" value="472" disabled="disabled">
+                            whistler / squamish <small>(whi)</small>
+                        </label>
+                        </li>
+
+                        <li>
+                        <span class="nextNearbyZone linklike" data-zone="1">
+                            + show <span id="nearbyNumber">3</span> more...
+                        </span>
+                        </li>
+                </ul>
+        </div>
+
+            <div class="searchgroup">
+                <span class="searchfieldlabel">km from postal code</span>
+                <input size="5" maxlength="5" inputmode="numeric" class="flatinput searchInput search_distance" placeholder="km" name="search_distance" value="">
+                <input type="text" class="flatinput searchInput postal" placeholder="from postal" size="7" name="postal" value="">
+                <span class="icon icon-locate"></span>
+            </div>
+
+
+    <div class="searchgroup minmax price" id="price">
+<span class="searchfieldlabel">price</span>
+    <input type="tel" name="min_price" class="flatinput min" placeholder="min" title="whole number, no letters or symbols" value="">
+    <input type="tel" name="max_price" class="flatinput max" placeholder="max" title="whole number, no letters or symbols" value="">
+</div>
+
+
+  <div class="searchgroup bed-bath-selects">
+    <span class="searchfieldlabel">bedrooms</span>
+    <select name="min_bedrooms" class="autosubmit">
+      <option value="">min</option>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+    </select>
+    -
+    <select name="max_bedrooms" class="autosubmit">
+      <option value="">max</option>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+    </select>
+  </div>
+
+  <div class="searchgroup bed-bath-selects">
+    <span class="searchfieldlabel">bathrooms</span>
+    <select name="min_bathrooms" class="autosubmit">
+      <option value="">min</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+    </select>
+    -
+    <select name="max_bathrooms" class="autosubmit">
+      <option value="">max</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+    </select>
+  </div>
+
+    <div class="searchgroup minmax " id="">
+<span class="searchfieldlabel">ft<sup>2</sup></span>
+    <input type="tel" name="minSqft" class="flatinput min" placeholder="min" title="whole number, no letters or symbols" value="">
+    <input type="tel" name="maxSqft" class="flatinput max" placeholder="max" title="whole number, no letters or symbols" value="">
+</div>
+
+<div class="searchgroup">
+  <span class="searchfieldlabel">availability</span>
+  <select class="autosubmit" name="availabilityMode">
+        <option value="0">all dates</option>
+        <option value="1">within 30 days</option>
+        <option value="2">beyond 30 days</option>
+ </select>
+</div>
+
+<div class="searchgroup" id="search-group-text">
+</div>
+
+<div class="searchgroup" id="search-group-range">
+</div>
+
+<div class="searchgroup" id="search-group-checkbox">
+<label class="pets_cat">
+        <input type="checkbox" name="pets_cat" value="1" class="autosubmit">
+    cats ok
+</label><br>
+<label class="pets_dog">
+        <input type="checkbox" name="pets_dog" value="1" class="autosubmit">
+    dogs ok
+</label><br>
+<label class="is_furnished">
+        <input type="checkbox" name="is_furnished" value="1" class="autosubmit">
+    furnished
+</label><br>
+<label class="no_smoking">
+        <input type="checkbox" name="no_smoking" value="1" class="autosubmit">
+    no smoking
+</label><br>
+<label class="wheelchaccess">
+        <input type="checkbox" name="wheelchaccess" value="1" class="autosubmit">
+    wheelchair access
+</label><br>
+<label class="ev_charging">
+        <input type="checkbox" name="ev_charging" value="1" class="autosubmit">
+    EV charging
+</label><br>
+<label class="application_fee">
+        <input type="checkbox" name="application_fee" value="1" class="autosubmit">
+    no application fee
+</label><br>
+<label class="broker_fee">
+        <input type="checkbox" name="broker_fee" value="1" class="autosubmit">
+    no broker fee
+</label><br>
+</div>
+
+<div class="searchgroup" id="search-group-multi_checkbox">
+<div class="search-attribute hide-list" data-attr="housing_type">
+    <div class="title linklike ">
+        <span class="plus">▸</span><span class="minus">▾</span> housing type
+    </div>
+
+        <ul class="list">
+
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_1" name="housing_type" class="multi_checkbox" value="1" type="checkbox">
+                    apartment
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_2" name="housing_type" class="multi_checkbox" value="2" type="checkbox">
+                    condo
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_3" name="housing_type" class="multi_checkbox" value="3" type="checkbox">
+                    cottage/cabin
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_4" name="housing_type" class="multi_checkbox" value="4" type="checkbox">
+                    duplex
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_5" name="housing_type" class="multi_checkbox" value="5" type="checkbox">
+                    flat
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_6" name="housing_type" class="multi_checkbox" value="6" type="checkbox">
+                    house
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_7" name="housing_type" class="multi_checkbox" value="7" type="checkbox">
+                    in-law
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_8" name="housing_type" class="multi_checkbox" value="8" type="checkbox">
+                    loft
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_9" name="housing_type" class="multi_checkbox" value="9" type="checkbox">
+                    townhouse
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_10" name="housing_type" class="multi_checkbox" value="10" type="checkbox">
+                    manufactured
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_11" name="housing_type" class="multi_checkbox" value="11" type="checkbox">
+                    assisted living
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="housing_type_12" name="housing_type" class="multi_checkbox" value="12" type="checkbox">
+                    land
+                </label>
+            </li>
+
+            <li class="selectall js-only ">
+                <span class="all">select all</span>
+                <span class="none">deselect all</span>
+            </li>
+
+
+    </ul>
+</div>
+<div class="search-attribute hide-list" data-attr="laundry">
+    <div class="title linklike ">
+        <span class="plus">▸</span><span class="minus">▾</span> laundry
+    </div>
+
+        <ul class="list">
+
+            <li class="checkbox ">
+                <label>
+                    <input id="laundry_1" name="laundry" class="multi_checkbox" value="1" type="checkbox">
+                    w/d in unit
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="laundry_4" name="laundry" class="multi_checkbox" value="4" type="checkbox">
+                    w/d hookups
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="laundry_2" name="laundry" class="multi_checkbox" value="2" type="checkbox">
+                    laundry in bldg
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="laundry_3" name="laundry" class="multi_checkbox" value="3" type="checkbox">
+                    laundry on site
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="laundry_5" name="laundry" class="multi_checkbox" value="5" type="checkbox">
+                    no laundry on site
+                </label>
+            </li>
+
+
+
+    </ul>
+</div>
+<div class="search-attribute hide-list" data-attr="parking">
+    <div class="title linklike ">
+        <span class="plus">▸</span><span class="minus">▾</span> parking
+    </div>
+
+        <ul class="list">
+
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_1" name="parking" class="multi_checkbox" value="1" type="checkbox">
+                    carport
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_2" name="parking" class="multi_checkbox" value="2" type="checkbox">
+                    attached garage
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_3" name="parking" class="multi_checkbox" value="3" type="checkbox">
+                    detached garage
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_4" name="parking" class="multi_checkbox" value="4" type="checkbox">
+                    off-street parking
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_5" name="parking" class="multi_checkbox" value="5" type="checkbox">
+                    street parking
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_6" name="parking" class="multi_checkbox" value="6" type="checkbox">
+                    valet parking
+                </label>
+            </li>
+            <li class="checkbox ">
+                <label>
+                    <input id="parking_7" name="parking" class="multi_checkbox" value="7" type="checkbox">
+                    no parking
+                </label>
+            </li>
+
+            <li class="selectall js-only ">
+                <span class="all">select all</span>
+                <span class="none">deselect all</span>
+            </li>
+
+
+    </ul>
+</div>
+</div>
+
+
+            <div class="searchgroup">
+                    <div class="searchfieldlabel">open house date</div>
+                <select class="autosubmit" id="sale_date" name="sale_date">
+                    <option>all dates</option>
+                        <option value="2021-02-25">feb 25 - today</option>
+                        <option value="2021-02-26">feb 26 - tomorrow</option>
+                        <option value="2021-02-27">feb 27 - saturday</option>
+                        <option value="2021-02-28">feb 28 - sunday</option>
+                        <option value="2021-03-01">mar 1 - monday</option>
+                        <option value="2021-03-02">mar 2 - tuesday</option>
+                        <option value="2021-03-03">mar 3 - wednesday</option>
+                        <option value="2021-03-04">mar 4 - thursday</option>
+                        <option value="2021-03-05">mar 5 - friday</option>
+                        <option value="2021-03-06">mar 6 - saturday</option>
+                        <option value="2021-03-07">mar 7 - sunday</option>
+                        <option value="2021-03-08">mar 8 - monday</option>
+                        <option value="2021-03-09">mar 9 - tuesday</option>
+                        <option value="2021-03-10">mar 10 - wednesday</option>
+                        <option value="2021-03-11">mar 11 - thursday</option>
+                        <option value="2021-03-12">mar 12 - friday</option>
+                        <option value="2021-03-13">mar 13 - saturday</option>
+                        <option value="2021-03-14">mar 14 - sunday</option>
+                        <option value="2021-03-15">mar 15 - monday</option>
+                        <option value="2021-03-16">mar 16 - tuesday</option>
+                        <option value="2021-03-17">mar 17 - wednesday</option>
+                        <option value="2021-03-18">mar 18 - thursday</option>
+                        <option value="2021-03-19">mar 19 - friday</option>
+                        <option value="2021-03-20">mar 20 - saturday</option>
+                        <option value="2021-03-21">mar 21 - sunday</option>
+                        <option value="2021-03-22">mar 22 - monday</option>
+                        <option value="2021-03-23">mar 23 - tuesday</option>
+                        <option value="2021-03-24">mar 24 - wednesday</option>
+                </select>
+            </div>
+        <div class="searchgroup resetsearch">
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" title="clear all search parameters" class="reset linklike">reset</a>
+            <button type="submit" class="searchlink linklike">update search</button>
+        </div>
+
+<aside class="tsb">
+    <ul>
+        <li><a href="https://www.craigslist.org/about/FHA">fair housing</a>
+        </li><li><a href="https://www.craigslist.org/about/scams">avoiding scams</a>
+    </li></ul>
+</aside>
+    </div>
+</div>
+
+
+            <div class="search-legend">
+<div class="search-view js-only">
+    <div class="dropdown dropdown-icons dropdown-arrows dropdown-view" role="toolbar" aria-label="view options" aria-expanded="false">
+        <ul class="dropdown-list">
+            <li class="dropdown-item mode" aria-selected="false">
+                <button title="show results in a list" data-selection="list" id="listview">
+                    <span class="view-list icon"></span>list
+                </button>
+                <span class="toggle-arrow"></span>
+            </li>
+            <li class="dropdown-item mode" aria-selected="false">
+                <button title="show results in a list with thumbnail pictures" data-selection="pic" id="picview">
+                    <span class="view-thumb icon"></span>thumb
+                </button>
+                <span class="toggle-arrow"></span>
+            </li>
+            <li class="dropdown-item mode sel" aria-selected="true">
+                <button title="show results side-by-side with larger pictures" data-selection="grid" id="gridview">
+                    <span class="view-gallery icon"></span>gallery
+                </button>
+                <span class="toggle-arrow"></span>
+            </li>
+                <li class="dropdown-item mode" aria-selected="false">
+                    <button title="show results on a map" data-selection="map" id="mapview">
+                        <span class="view-map icon"></span>map
+                    </button>
+                    <span class="toggle-arrow"></span>
+                </li>
+        </ul>
+    </div>
+</div>
+                <div class="search-sort">
+    <div class="dropdown dropdown-sort dropdown-arrows" data-default-sort="date" role="toolbar" aria-label="sort options" aria-expanded="false">
+        <ul class="dropdown-list">
+
+            <li class="dropdown-item mode " aria-selected="false">
+                <a data-selection="upcoming" title="show upcoming open houses" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?sort=upcoming&amp;">upcoming <span class="toggle-arrow"></span></a>
+            </li>
+            <li class="dropdown-item mode sel" aria-selected="true">
+                <a data-selection="date" title="show newest matches first" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?sort=date&amp;">newest <span class="toggle-arrow"></span></a>
+            </li>
+            <li class="dropdown-item mode " aria-selected="false">
+                <a data-selection="priceasc" title="sort by price, lowest to highest" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?sort=priceasc&amp;">price ↑ <span class="toggle-arrow"></span></a>
+            </li>
+            <li class="dropdown-item mode " aria-selected="false">
+                <a data-selection="pricedsc" title="sort by price, highest to lowest" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?sort=pricedsc&amp;">price ↓ <span class="toggle-arrow"></span></a>
+            </li>
+
+        </ul>
+    </div>
+</div>
+
+                <div class="paginator buttongroup firstpage">
+    <span class="resulttotal">
+        <span class="for-map">
+        showing <span class="displaycountShow">...</span> postings
+        <span class="zoom-out-for-more" style="display: none">
+            -
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa">
+                zoom out for all <span class="total">3000</span>
+            </a>
+        </span>
+
+        </span>
+    </span>
+    <span class="buttons">
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" class="button first" title="first page">&lt;&lt;</a>
+        <span class="button first" title="first page">&lt;&lt;</span>
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" class="button prev" title="previous page">&lt; prev</a>
+        <span class="button prev" title="previous page">&lt; prev</span>
+
+        <span class="button pagenum">
+            <span class="range">
+                <span class="rangeFrom">1</span>
+                -
+                <span class="rangeTo">120</span>
+            </span>
+            /
+            <span class="totalcount">3000</span>
+        </span>
+
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?s=120" class="button next" title="next page">next &gt; </a>
+        <span class="button next" title="next page"> next &gt; </span>
+    </span>
+</div>
+
+                
+            </div>
+            <div class="content" id="sortable-results">
+                <section class="favlistsection">
+                    <section class="favlistinfo">
+                    </section>
+                    <section class="banishlistinfo">
+                    </section>
+                </section>
+
+
+                    
+
+
+<div class="open-map-view-button">
+    <span>see in map view</span>
+</div>
+<div id="mapcontainer" data-arealat="49.250500" data-arealon="-123.112000">
+    <div id="noresult-overlay"></div>
+    <div id="noresult-text">
+        <span class="message">No mappable items found</span>
+    </div>
+    <div id="map" class="loading" style="height: 200px;">
+        <div class="close-full-screen-map-mode-button">close fullscreen</div>
+    </div>
+</div>
+
+                <ul class="rows">
+                             <li class="result-row" data-pid="7282955370">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-must-see-1br-suite/7282955370.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:26" title="Thu 25 Feb 06:26:18 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-must-see-1br-suite/7282955370.html" data-id="7282955370" class="result-title hdrlnk" id="postid_7282955370">*** MUST SEE 1BR Suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,250</span>
+
+                <span class="housing">
+                    1br -
+                    600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Highgate Burnaby)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7273877138" data-repost-of="7236950981">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-bedroom-basement-for-rent/7273877138.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:25" title="Thu 25 Feb 06:25:57 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-bedroom-basement-for-rent/7273877138.html" data-id="7273877138" class="result-title hdrlnk" id="postid_7273877138">2 bedroom basement for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,300</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (PANORAMA SURREY)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281114393" data-repost-of="7258030497">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom/7281114393.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:20" title="Thu 25 Feb 06:20:06 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom/7281114393.html" data-id="7281114393" class="result-title hdrlnk" id="postid_7281114393">Furnished one bedroom apartment in downtown</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282953218">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-yaletown-one-pacific-fully/7282953218.html" class="result-image gallery" data-ids="3:00E0E_28KpW4QVwH8z_0ak06T,3:01010_cBgP2uVorQlz_1320MM,3:00808_6JiLZytGDzzz_1320MM,3:00Y0Y_6Wh9fUBoQxLz_1320MM,3:00909_fBebXkn8dB4z_0ne0hq,3:00909_14gOYAIfCHVz_1320MM,3:00v0v_9eo9bS6UdvQz_1320MM,3:00303_1WDylPiD7Nbz_1320MM,3:00x0x_jJsRm8TAGCzz_1320MM,3:00x0x_5ey85mxZ4N9z_0ne0hq,3:00d0d_17VO2co53Lz_0ne0hq,3:00e0e_iABnSadIUoUz_0ne0hq,3:00s0s_5vpIJftPHHwz_1320MM,3:00I0I_8pTNmjNqG4kz_0ne0hq,3:00o0o_53Y2S2j1odbz_0ne0hq,3:00202_1afPRDkFkS1z_0gw0co">
+                <span class="result-price">$3,695</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00E0E_28KpW4QVwH8z_0ak06T_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 16</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:18" title="Thu 25 Feb 06:18:51 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-yaletown-one-pacific-fully/7282953218.html" data-id="7282953218" class="result-title hdrlnk" id="postid_7282953218">Yaletown One Pacific Fully Furnished 2 bed/2bath(Internet,hydro incl.)</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,695</span>
+
+                <span class="housing">
+                    2br -
+                    900ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Yaletown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7272139408">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-amazing-amenities/7272139408.html" class="result-image gallery" data-ids="3:00f0f_5QJOqWp8E4Lz_0ww0oo,3:00d0d_5RGP35Zugdvz_0oo0ww,3:00101_4pl73wCVonGz_0oo0ww,3:00Q0Q_6h3EGl5h6fTz_0oo0ww,3:00w0w_7lc8B32YRJKz_0oo0ww,3:00e0e_aT0IktSkqXvz_0oo0ww,3:00101_8KlyjuOhM5Sz_0oo0ww,3:00B0B_41lyaNxyfbzz_0oo0ww,3:00q0q_8JYlFIJVRRRz_0oo0ww,3:00G0G_hOb4vBWDvUhz_0oo0ww,3:00A0A_8b3ihe3alUtz_0oo0ww,3:00N0N_aAnx7Xff9zHz_0oo0ww,3:00m0m_d205bMrthyiz_0oo0ww,3:01616_3VtBET4ps2z_0oo0ww,3:00b0b_lgtsjGlNHYWz_0oo0ww,3:00505_1DHoEUpwHYxz_0oo0ww,3:00q0q_3NLxKoIQrkwz_0oo0ww,3:00K0K_dXM7HmThacyz_0oo0ww,3:00G0G_jcUiFjeHcprz_0oo0ww,3:00n0n_iLGAbxUKqcwz_0oo0ww,3:00w0w_bfSO81dOtQhz_0oo0ww,3:00404_klRCO96xkvxz_0oo0ww,3:00404_fN3I4TweTsNz_0oo0ww">
+                <span class="result-price">$2,390</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00f0f_5QJOqWp8E4Lz_0ww0oo_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="22" style="width: 300px; left: -6600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 23</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:18" title="Thu 25 Feb 06:18:28 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-amazing-amenities/7272139408.html" data-id="7272139408" class="result-title hdrlnk" id="postid_7272139408">2 bed 2 bath w/ amazing amenities</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,390</span>
+
+                <span class="housing">
+                    2br -
+                    748ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282952114" data-repost-of="4930455983">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/cozy-bedroom-apartment-6th-floor/7282952114.html" class="result-image gallery" data-ids="3:00u0u_3eG2YbNNatl_0CI0pV,3:00M0M_lRI76JVQscZ_0CI0pV,3:00I0I_8iqIEqqaqAU_0CI0pV,3:01515_jm88bPtQw4i_0CI0pV,3:00303_8eLEJgDom7Fz_0CI0pV,3:00I0I_b2w5d91T0M6z_0CI0pV">
+                <span class="result-price">$1,675</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00u0u_3eG2YbNNatl_0CI0pV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 6</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:18" title="Thu 25 Feb 06:18:15 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/cozy-bedroom-apartment-6th-floor/7282952114.html" data-id="7282952114" class="result-title hdrlnk" id="postid_7282952114">Cozy 1 bedroom apartment 6th floor balcony! English Bay View 6th Floor</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,675</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7272756858">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-br-br-2ba-suite-for-rent/7272756858.html" class="result-image gallery" data-ids="3:01515_8kPDvHWVhnhz_0hq0ne,3:00a0a_5ideMIFHvAqz_0uY0hq,3:00I0I_7BaDuZxYiSTz_0gl0t2,3:00E0E_4c4F12czE2Sz_0aT0ew">
+                <span class="result-price">$1,700</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01515_8kPDvHWVhnhz_0hq0ne_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:17" title="Thu 25 Feb 06:17:46 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-br-br-2ba-suite-for-rent/7272756858.html" data-id="7272756858" class="result-title hdrlnk" id="postid_7272756858">$1,700 / 3br - $1700 3 BR 2BA Suite for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,700</span>
+
+                <span class="housing">
+                    3br -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282944538">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-inner-northwest-surrey-central/7282944538.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:17" title="Thu 25 Feb 06:17:26 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-inner-northwest-surrey-central/7282944538.html" data-id="7282944538" class="result-title hdrlnk" id="postid_7282944538">Surrey Central 1br+den for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$950</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (13364 102 Ave, Surrey, BC V3T 5L8, Canada)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282952069">
+
+        <a href="https://vancouver.craigslist.org/rch/apa/d/richmond-bed-15-bath-apartment/7282952069.html" class="result-image gallery" data-ids="3:00A0A_bdwDyChbg7uz_0CI0t2,3:00u0u_75M8hE2Y1lKz_0CI0t2,3:00707_6QLbIklHTrTz_0lM0t2,3:00P0P_8dd8NVompA6z_0lM0t2,3:00Z0Z_7g2PAMzhqrYz_0lM0t2,3:01212_dSYNRUzTBWkz_0lM0t2,3:00w0w_ivcUtf7MDx0z_0lM0t2,3:00l0l_i6aFL6Xqfy5z_0lM0t2,3:00L0L_iIn8LiKXiYoz_0CI0t2">
+                <span class="result-price">$1,850</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00A0A_bdwDyChbg7uz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:15" title="Thu 25 Feb 06:15:00 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rch/apa/d/richmond-bed-15-bath-apartment/7282952069.html" data-id="7282952069" class="result-title hdrlnk" id="postid_7282952069">2 bed &amp; 1.5 bath apartment</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    2br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Richmond)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282951962">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-big-bd-bath-den-for-2600/7282951962.html" class="result-image gallery" data-ids="3:00D0D_4QAWfO6iJfiz_0c60lw,3:00E0E_iJA39KGLFRuz_0c60lw,3:00H0H_aTPUqBV2YiVz_0c60lw,3:00v0v_9m8CE6bCUAoz_0c60lw,3:00e0e_82QVvuyMk2Zz_0c60lw,3:01515_ld0BhkZpCwz_0c60lw,3:00V0V_a3MdRTteKJz_0c60lw,3:00r0r_2bB2ICMGOxiz_0c60lw,3:00101_iw7wROO9Pgyz_0c60lw">
+                <span class="result-price">$2,600</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00D0D_4QAWfO6iJfiz_0c60lw_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:14" title="Thu 25 Feb 06:14:40 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-big-bd-bath-den-for-2600/7282951962.html" data-id="7282951962" class="result-title hdrlnk" id="postid_7282951962">Big 2 BD 2 Bath &amp; Den for $2,600</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,600</span>
+
+                <span class="housing">
+                    2br -
+                    935ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282951905" data-repost-of="4930455983">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/charming-bedroom-apartment-with-balcony/7282951905.html" class="result-image gallery" data-ids="3:00u0u_3eG2YbNNatl_0CI0pV,3:00M0M_lRI76JVQscZ_0CI0pV,3:00I0I_8iqIEqqaqAU_0CI0pV,3:01515_jm88bPtQw4i_0CI0pV">
+                <span class="result-price">$1,575</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00u0u_3eG2YbNNatl_0CI0pV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:14" title="Thu 25 Feb 06:14:30 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/charming-bedroom-apartment-with-balcony/7282951905.html" data-id="7282951905" class="result-title hdrlnk" id="postid_7282951905">Charming 1 bedroom apartment with balcony! English Bay View 5th floor</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,575</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282951490" data-repost-of="4930455983">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/cozy-2nd-floor-bedroom-apartment-with/7282951490.html" class="result-image gallery" data-ids="3:00u0u_3eG2YbNNatl_0CI0pV,3:00M0M_lRI76JVQscZ_0CI0pV,3:00I0I_8iqIEqqaqAU_0CI0pV,3:01515_jm88bPtQw4i_0CI0pV">
+                <span class="result-price">$1,550</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00u0u_3eG2YbNNatl_0CI0pV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:13" title="Thu 25 Feb 06:13:10 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/cozy-2nd-floor-bedroom-apartment-with/7282951490.html" data-id="7282951490" class="result-title hdrlnk" id="postid_7282951490">Cozy 2nd floor  1 bedroom apartment with balcony!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,550</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282951087">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-br-540ft2-amazing-brentwood/7282951087.html" class="result-image gallery" data-ids="3:00707_8AgtHnqoT0rz_0CI0t2,3:01717_fRD1i8RuEosz_0CI0t2,3:00D0D_lOvoyQxdbz0z_0CI0t2,3:00v0v_g6RWFfMeZCoz_0CI0t2,3:00V0V_fgxY9tyg6IYz_0CI0t2,3:00808_e7s7HoJ2xjJz_0t20CI,3:00808_e7s7HoJ2xjJz_0t20CI,3:00j0j_94rn0QbMOWUz_0t20CI,3:00303_7cR5e9LBv97z_0t20CI,3:00I0I_hV7UdRSDWnZz_0t20CI,3:00808_9aei03b06Mxz_0t20CI,3:00W0W_2KF9LVDcbRkz_0t20CI">
+                <span class="result-price">$1,850</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00707_8AgtHnqoT0rz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:11" title="Thu 25 Feb 06:11:49 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-br-540ft2-amazing-brentwood/7282951087.html" data-id="7282951087" class="result-title hdrlnk" id="postid_7282951087">$1,850 / 1br - 540ft2 - Amazing Brentwood - Gorgeous South facing</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    540ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Metro Town View (Burnaby))</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282950434">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-bedrooms-large-suite/7282950434.html" class="result-image gallery" data-ids="3:01515_ehTnSMehOo5z_08c08N"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01515_ehTnSMehOo5z_08c08N_300x300.jpg">
+                <span class="result-price">$2,000</span>
+        </a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:09" title="Thu 25 Feb 06:09:40 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-bedrooms-large-suite/7282950434.html" data-id="7282950434" class="result-title hdrlnk" id="postid_7282950434">*Two Bedrooms * Large Suite * Furnished *Short-Term* All inclusive</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    2br -
+                    850ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver near skytrain station)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280859853">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-elevators-social-room-bike/7280859853.html" class="result-image gallery" data-ids="3:00l0l_g0162NeAcfSz_0ew0eS,3:00L0L_4ugzVuRELyTz_05E06l,3:00f0f_jxZ6xz55iscz_0io0bp,3:00808_2MULFM3uK1Vz_0io0cv,3:00K0K_kYlK5WOgUxnz_0io0cy,3:00f0f_chLixi87Ro4z_0ew09C,3:00S0S_jg7Cy0E1vpBz_0io0co,3:01313_9VPHP11j71dz_0io0aW,3:00h0h_2Mgyque0UQHz_0io0ch,3:00I0I_lrfSCSSvOllz_0io0cr,3:00I0I_5QpovbRtiwMz_0SQ0zu">
+                <span class="result-price">$1,695</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00l0l_g0162NeAcfSz_0ew0eS_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:09" title="Thu 25 Feb 06:09:03 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-elevators-social-room-bike/7280859853.html" data-id="7280859853" class="result-title hdrlnk" id="postid_7280859853">2 elevators, Social room, Bike Storage</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,695</span>
+
+                <span class="housing">
+                    399ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280815348">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/new-westminster-southwest-large-bedroom/7280815348.html" class="result-image gallery" data-ids="3:00404_lFZCEZtXkZEz_0CI0t2,3:00w0w_aKeCwzwhVioz_0CI0t2,3:01616_cSx19tuccvJz_0t20CI,3:00v0v_9E5gndDCUVyz_0t20CI">
+                <span class="result-price">$1,450</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00404_lFZCEZtXkZEz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:08" title="Thu 25 Feb 06:08:43 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/new-westminster-southwest-large-bedroom/7280815348.html" data-id="7280815348" class="result-title hdrlnk" id="postid_7280815348">Large 1 bedroom for Rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,450</span>
+
+                <span class="housing">
+                    1br -
+                    900ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Queensborough, New Westminster)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282942222">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-bedroom-bath/7282942222.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:08" title="Thu 25 Feb 06:08:36 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-bedroom-bath/7282942222.html" data-id="7282942222" class="result-title hdrlnk" id="postid_7282942222">BRAND NEW 1 Bedroom, 1 Bath Apartment near Bus Station</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,100</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (8940 University Crescent, Burnaby, BC V5A 0E7, Canada)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7275260418">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-brentwood-lumina-bed/7275260418.html" class="result-image gallery" data-ids="3:00B0B_6H0tiHJds6az_1320MM,3:00L0L_6pMGCyDKfj9z_1320MM,3:00707_lq6dO24tjaGz_1320MM,3:01717_icCiznvwLiAz_1320MM,3:00P0P_cwJ5LRaEyqlz_1320MM,3:01111_JpOCHgNRKvz_1320MM,3:00F0F_hUp0l8twm5tz_1320MM,3:00B0B_84hVbrV4mkPz_1320MM,3:00V0V_hstDxtuQB7Qz_1320MM,3:00J0J_1EIgoOyGVRdz_1320MM,3:00T0T_bEqvPO6zBctz_1320MM,3:00t0t_9EURs6W6Ht0z_1320MM,3:00w0w_abRkgIzYg67z_1320MM,3:00y0y_5kxoeVjpZOcz_1320MM,3:00606_dwan1ZfZb4Uz_1320MM">
+                <span class="result-price">$1,750</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00B0B_6H0tiHJds6az_1320MM_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:06" title="Thu 25 Feb 06:06:42 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-brentwood-lumina-bed/7275260418.html" data-id="7275260418" class="result-title hdrlnk" id="postid_7275260418">Brand New Brentwood Lumina 1 bed best view for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,750</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Brentwood, Burnaby)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282949195">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-bedroom-apartment-lower/7282949195.html" class="result-image gallery" data-ids="3:00O0O_gJ58eGweQloz_0ak06S,3:01717_D3KbTz5Pi6z_0lM0t2,3:00B0B_dIIqwhnA3fcz_0ak06S,3:00F0F_jgbI3JF2pMVz_0lM0t2,3:00z0z_jFgGAyZGJLbz_0ak06S,3:00S0S_az0kIcO52o1z_0lM0t2,3:00o0o_eZJHcLvXFChz_0lM0t2,3:00Z0Z_5Pc45IQsn8Tz_0lM0t2,3:00202_1x2jUx0HcAXz_0lM0t2,3:00303_eFKZoCiFPepz_0lM0t2,3:00g0g_3qbD5EWKy0wz_0lM0t2,3:00b0b_fzW4pZ2o9E4z_0bC0bC">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00O0O_gJ58eGweQloz_0ak06S_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:06" title="Thu 25 Feb 06:06:07 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-bedroom-apartment-lower/7282949195.html" data-id="7282949195" class="result-title hdrlnk" id="postid_7282949195">2 Bedroom Apartment lower Lonsdale</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                    769ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Lower Lonsdale)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7272374512" data-repost-of="7171157278">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-yaletown-furnished-dining/7272374512.html" class="result-image gallery" data-ids="3:00m0m_bgizMLwU3yrz_0CI0t2,3:00p0p_dHZ1r5npsL0z_0CI0t2,3:00f0f_3jHe6AVyznpz_0CI0t2,3:00808_1rLIwcyARSbz_0CI0t2,3:00j0j_eIcYDDWwmIuz_0CI0t2,3:00t0t_b0YZsm4eTCXz_0CI0t2,3:00a0a_eDeteJAYDmCz_0lM0t2,3:00303_9mOqaMawXQEz_0t20CI,3:00U0U_byhDkEPHI3mz_0lM0t2,3:00000_aONav8NM78cz_0lM0t2,3:01414_eJf5lksEvZaz_0CI0t2,3:00p0p_fDbQhm9ASaez_0t20CI,3:00m0m_6MU0TZhRlmFz_0CI0t2,3:00303_e2eAERas16Dz_0t20CI,3:01313_kKGuRygvuoXz_0CI0t2,3:01414_64W66qX45V8z_09X08e,3:00I0I_8KI3cWjZuIpz_0CI0t2,3:00H0H_dkYhzCjwASoz_0b20dG">
+                <span class="result-price">$2,700</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_bgizMLwU3yrz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:05" title="Thu 25 Feb 06:05:34 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-yaletown-furnished-dining/7272374512.html" data-id="7272374512" class="result-title hdrlnk" id="postid_7272374512">Yaletown Furnished + Dining room + Office + Parking</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,700</span>
+
+                <span class="housing">
+                    1br -
+                    682ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (977 Mainland, Yaletown Park 3, Downtown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7269309131" data-repost-of="5068523786">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/beautiful-bedroom-basement-suite-for/7269309131.html" class="result-image gallery" data-ids="3:00O0O_2xGmT5tHAYmz_0kE0uY,3:00303_2PfyNVgeteiz_0hq0d4,3:00r0r_2K1dfOqIIkPz_0hq0ne,3:00404_7BkUddzCqLjz_0hq0d4,3:00s0s_766fDDk4sMez_0hq0d4,3:00w0w_WOmxZbVveUz_0hq0d4,3:00V0V_bZkaiEblKLFz_0hq0ne,3:01313_1PWfwbPyAERz_0hq0d4,3:01313_1PWfwbPyAERz_0hq0d4,3:00E0E_kVsqIjyZOjAz_0hq0ne,3:00d0d_jXAssuMr76Hz_0hq0d4,3:00n0n_2EyjDw8pHeIz_0hq0d4,3:01616_9LNvIVqSGOkz_0hq0d4,3:00C0C_c6fezJo9At6z_0hq0ne,3:00P0P_YF7zuFpeO9z_0hq0d4">
+                <span class="result-price">$1,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00O0O_2xGmT5tHAYmz_0kE0uY_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:05" title="Thu 25 Feb 06:05:28 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/beautiful-bedroom-basement-suite-for/7269309131.html" data-id="7269309131" class="result-title hdrlnk" id="postid_7269309131">Beautiful 2 Bedroom Basement Suite For Rent available-1st March 2021</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,500</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Sullivan Heights/141 Street And 60A Ave.)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7278830867">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bright-bed-newly-renoed/7278830867.html" class="result-image gallery" data-ids="3:00707_8wLZJouoqP1z_0t20CI,3:00g0g_ltah3oFLG3wz_0t20CI,3:00H0H_i3a31JvZSZKz_0t20CI,3:00o0o_klHYMv8WxCjz_0t20CI,3:00d0d_8EuY7hcB2cNz_0t20CI,3:00H0H_Isqn51XixSz_0t20CI,3:00Z0Z_heo2SlVzqkWz_0t20CI,3:01313_6ffqt0Bww1bz_0t20CI,3:01717_7avGobTINQJz_0t20CI,3:00B0B_jFLFAANEB1rz_0t20CI,3:00G0G_37TqSbPk7u7z_0t20CI,3:01111_jzMXvUO46YQz_0t20CI,3:00M0M_bu2g8E395SRz_0t20CI">
+                <span class="result-price">$2,950</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00707_8wLZJouoqP1z_0t20CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 13</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:04" title="Thu 25 Feb 06:04:55 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bright-bed-newly-renoed/7278830867.html" data-id="7278830867" class="result-title hdrlnk" id="postid_7278830867">Bright 2 Bed- Newly Renoed</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,950</span>
+
+                <span class="housing">
+                    2br -
+                    950ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver West End)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279450223">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-brand-new-basement-suite-best/7279450223.html" class="result-image gallery" data-ids="3:00C0C_cc4NHaRLnPsz_0kE0dN,3:00V0V_fm0ky3kZAPtz_0kE0dN,3:00b0b_bgGjzLKrl3Gz_0kE0dM,3:00o0o_jTMR60y6b0Dz_0kE0dN,3:00Q0Q_hFTFf0wAUiOz_0kE0dM">
+                <span class="result-price">$1,650</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00C0C_cc4NHaRLnPsz_0kE0dN_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:04" title="Thu 25 Feb 06:04:48 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-brand-new-basement-suite-best/7279450223.html" data-id="7279450223" class="result-title hdrlnk" id="postid_7279450223">Brand new basement suite – BEST LOCATION off Main St.</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,650</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (Main &amp; 22nd)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282948173" data-repost-of="7268045061">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/vancouver-bedroom-condo/7282948173.html" class="result-image gallery" data-ids="3:01111_jYgtZ9BOBvxz_07g07g,3:00r0r_hTlwT35Jq0nz_08u08u,3:00T0T_4oUZWTJc8SRz_08u08u,3:01313_27m6PVksD6Fz_08I08I,3:00P0P_7STZTfV6kTxz_08I08I,3:00404_7k0l2QSHnnxz_08I08I,3:00r0r_2BycAWY2oDfz_08I08I,3:00202_ecJqFlLv3ygz_08I08I,3:00L0L_leeHHZ5cAEdz_08I08I,3:00r0r_bbNfJ6jgFyuz_08u08u,3:00o0o_lkdn8jLCrXfz_08I08I,3:00U0U_kVbIHDnP7PXz_08u08u,3:00g0g_4T2XEGDOpY1z_08I08I">
+                <span class="result-price">$1,750</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01111_jYgtZ9BOBvxz_07g07g_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 13</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:03" title="Thu 25 Feb 06:03:14 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/vancouver-bedroom-condo/7282948173.html" data-id="7282948173" class="result-title hdrlnk" id="postid_7282948173">1 Bedroom Condo</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,750</span>
+
+                <span class="housing">
+                    1br -
+                    505ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown, Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282941017">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bed-bath-brand-new-beautiful/7282941017.html" class="result-image gallery" data-ids="3:00S0S_61ja7CUWlAXz_0CI0il,3:00m0m_3bAHo3UgtHCz_0CI0il,3:00b0b_1914wLeYzn1z_0CI0il,3:00707_jvISr5ZNJQ4z_0CI0sk,3:01717_fevXcHt7a0fz_0CI0il,3:01414_4wF01FuXnphz_0CI0rS,3:00404_93WlFvTTau8z_0CI0ik,3:00707_ePRzK3xgheqz_0CI0ik,3:00j0j_kB7x7fkvkB4z_0dL0t2,3:00404_kKarZLXpzaDz_0CI0il,3:00F0F_fKV14ITFZKRz_0CI0il,3:00K0K_bV5cngihaqiz_0dL0t2,3:00h0h_6sOIRQ4Xk4jz_0dL0t2,3:00K0K_38EtzxWgoS8z_09G07g,3:00L0L_l51Xu701q6Lz_0jj0ew">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00S0S_61ja7CUWlAXz_0CI0il_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:02" title="Thu 25 Feb 06:02:12 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bed-bath-brand-new-beautiful/7282941017.html" data-id="7282941017" class="result-title hdrlnk" id="postid_7282941017">☎☎ 2 bed/2 bath, Brand New, Beautiful view, Balcony - Brentwood Mall</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                    720ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Amazing Brentwood 3)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936200">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bed-bath-brand-new-beautiful/7282936200.html" class="result-image gallery" data-ids="3:00S0S_61ja7CUWlAXz_0CI0il,3:00m0m_3bAHo3UgtHCz_0CI0il,3:00b0b_1914wLeYzn1z_0CI0il,3:00707_jvISr5ZNJQ4z_0CI0sk,3:01717_fevXcHt7a0fz_0CI0il,3:01414_4wF01FuXnphz_0CI0rS,3:00404_93WlFvTTau8z_0CI0ik,3:00707_ePRzK3xgheqz_0CI0ik,3:00j0j_kB7x7fkvkB4z_0dL0t2,3:00404_kKarZLXpzaDz_0CI0il,3:00F0F_fKV14ITFZKRz_0CI0il,3:00K0K_bV5cngihaqiz_0dL0t2,3:00h0h_6sOIRQ4Xk4jz_0dL0t2,3:00K0K_38EtzxWgoS8z_09G07g,3:00L0L_l51Xu701q6Lz_0jj0ew">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00S0S_61ja7CUWlAXz_0CI0il_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 18:01" title="Thu 25 Feb 06:01:32 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bed-bath-brand-new-beautiful/7282936200.html" data-id="7282936200" class="result-title hdrlnk" id="postid_7282936200">☎☎ 2 bed/2 bath, Brand New, Beautiful view, Balcony - Brentwood Mall</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                    720ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Amazing Brentwood 3)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7273141915">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-story-furnished-laneway/7273141915.html" class="result-image gallery" data-ids="3:00f0f_eH929ZHMA2zz_0nz0fI,3:00303_2LRzq2R1GGFz_0nz0fI,3:00505_2z7TpNcB1qRz_0lo0eg,3:00H0H_hdfhIS2bcn6z_0nz0fI,3:01717_gGcrbajMSFOz_0nz0fI,3:00R0R_luPeZmqTISaz_0nz0fI,3:00E0E_klgHOtKbLwLz_0nz0fI">
+                <span class="result-price">$1,980</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00f0f_eH929ZHMA2zz_0nz0fI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 7</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:57" title="Thu 25 Feb 05:57:24 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-story-furnished-laneway/7273141915.html" data-id="7273141915" class="result-title hdrlnk" id="postid_7273141915">Two story furnished laneway house in South of Vancouver available now!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,980</span>
+
+                <span class="housing">
+                    1br -
+                    700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282946060">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-chic-modern-basement-suite/7282946060.html" class="result-image gallery" data-ids="3:00000_kA3nvt0F71Gz_07K0ak,3:00n0n_fL7LLWKhPtBz_07K0ak,3:00u0u_fViCH4G7Jclz_07K0ak,3:00808_lMT6kqIG04nz_07K0ak,3:00e0e_2gw5wgcrjW1z_07K0ak,3:00X0X_lXMDNqFPN7pz_07K0ak,3:00W0W_eLEuPzqJYnzz_0jm0ex,3:00j0j_4kOwqTrN8GOz_0jm0ex">
+                <span class="result-price">$1,750</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_kA3nvt0F71Gz_07K0ak_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:56" title="Thu 25 Feb 05:56:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-chic-modern-basement-suite/7282946060.html" data-id="7282946060" class="result-title hdrlnk" id="postid_7282946060">Chic modern basement suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,750</span>
+
+                <span class="housing">
+                    2br -
+                    750ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280001939" data-repost-of="7277609348">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-main-floor-suite-in/7280001939.html" class="result-image gallery" data-ids="3:00u0u_dl9WMGd1aqHz_0ff0r6,3:00202_2Mxb3QMwkydz_0ff0r6,3:00J0J_1UDZwtwORkMz_0ff0r6,3:00T0T_dD13sOI664gz_0ff0r6">
+                <span class="result-price">$1,450</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00u0u_dl9WMGd1aqHz_0ff0r6_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:56" title="Thu 25 Feb 05:56:05 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-main-floor-suite-in/7280001939.html" data-id="7280001939" class="result-title hdrlnk" id="postid_7280001939">2 Bedroom Main Floor Suite in South Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,450</span>
+
+                <span class="housing">
+                    2br -
+                    700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282945433">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-bath-lease-takeover/7282945433.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:55" title="Thu 25 Feb 05:55:00 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-bath-lease-takeover/7282945433.html" data-id="7282945433" class="result-title hdrlnk" id="postid_7282945433">1 bedroom, 1 bath Lease takeover with incentives</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,007</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (Downtown Vancouver)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282944674">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7282944674.html" class="result-image gallery" data-ids="3:00v0v_gpmXXN7rGtbz_09G07g,3:00X0X_40e4Ryuigdtz_09G07g,3:00L0L_fhSBZlR8Vwkz_05r07g,3:00a0a_6jElcaBHGhiz_0jm0ew,3:00r0r_ccjLCjx2AChz_05r07g,3:00404_fZD6yNXuAPnz_0jm0ew,3:00a0a_gjK5D1WhaLzz_05r07g,3:00Y0Y_hWKUj9z6CsKz_05r07g,3:01414_9PvNO7DmKWzz_09G07g,3:00L0L_6XtmlfNf2vOz_03904c,3:00O0O_dkafMaXOUtBz_04c039,3:00d0d_gQKRXAQUUpjz_03904c,3:00X0X_avjEsijam4Fz_04Q03D,3:00r0r_6qiSNbIwDVcz_04Q02I,3:00z0z_bFsLdqf5lrHz_0jm0ew,3:00000_easW3X6RqBgz_09G07g,3:00B0B_53d7sgvPOgVz_04c039,3:00O0O_bA4jmV56asyz_04c039,3:00m0m_jhyvRcjMzEIz_04c039,3:00B0B_1ZCCYQd2Kn8z_04c039,3:00t0t_6xVP5PgAz32z_04c039">
+                <span class="result-price">$1,635</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00v0v_gpmXXN7rGtbz_09G07g_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 21</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:54" title="Thu 25 Feb 05:54:14 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7282944674.html" data-id="7282944674" class="result-title hdrlnk" id="postid_7282944674">One Bedroom Apartment/Cambie Village</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,635</span>
+
+                <span class="housing">
+                    1br -
+                    750ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282945077">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-kits-bedroom-and-den-large/7282945077.html" class="result-image gallery" data-ids="3:00w0w_eyw3GCRN4TSz_0lM0t2,3:00Q0Q_lUPmeUMfSRgz_0lM0t2,3:00Z0Z_8xPR4aaBHUWz_0lM0t2,3:00s0s_hfaNazj9qdYz_0lM0t2,3:00E0E_cQadvljgXJaz_0lM0t2,3:00s0s_kjUsPAe4ZMaz_0lM0t2,3:00p0p_1Kdp4uzRqxYz_0lM0t2,3:01616_3ptw4rPXUyzz_07K0ak,3:00j0j_sxDSt2vLugz_0lM0t2,3:00U0U_hhY4aDlryBZz_0lM0t2,3:01010_a58qg4Sh0Asz_0CI0t2,3:00707_go90GP8h4Sez_0t20CI,3:01414_ag5DzvxI2wz_0gw0co,3:00M0M_1YQrTecgqclz_0cU09G">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00w0w_eyw3GCRN4TSz_0lM0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 14</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:53" title="Thu 25 Feb 05:53:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-kits-bedroom-and-den-large/7282945077.html" data-id="7282945077" class="result-title hdrlnk" id="postid_7282945077">Kits 2 bedroom and den, large and sunny garden suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Kitsilano)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282941965" data-repost-of="6946545015">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-move-in-bonus-semi-furnished/7282941965.html" class="result-image gallery" data-ids="3:00g0g_1VfgupuAQlLz_0CI0t2,3:00808_dlufz96zKhz_0CI0t2,3:00o0o_he69o7FkA08z_0CI0t2,3:00d0d_eCIrc5UlQBfz_0CI0t2,3:00i0i_h3XHb60QssEz_0CI0t2,3:00l0l_5oPmwNLN7t9z_0CI0t2,3:00v0v_1ohk7oMPKXUz_0CI0t2,3:00A0A_6jC0W7tTBdaz_0CI0t2,3:00D0D_8Xu1cgOFvSTz_0CI0t2,3:01515_2PF5WVUwZIjz_0CI0t2,3:00O0O_4OPoRQCVr9Tz_0CI0t2,3:00f0f_k7ymTWaW2bpz_0mr0t2,3:00l0l_8kBmseTG8PSz_0y40mI,3:00H0H_f3bXCkLcg6gz_0xS0mA,3:00y0y_d4rSLeyyhLvz_0CI0pO,3:00x0x_1xAPV5xjQC9z_0vW0li,3:00606_86B3uZXHNjkz_0xS0oQ,3:00i0i_lrftPB3gxpIz_0CI0pO,3:00U0U_6E8bieDWZcbz_0xS0mA,3:00y0y_jKkHsWGSJsJz_0xS0mA,3:00h0h_98Fc3EyeLZSz_0CI0pO,3:00808_f4frnXZYeb1z_0CI0pO">
+                <span class="result-price">$1,550</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00g0g_1VfgupuAQlLz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 22</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:52" title="Thu 25 Feb 05:52:55 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-move-in-bonus-semi-furnished/7282941965.html" data-id="7282941965" class="result-title hdrlnk" id="postid_7282941965">Move-in BONUS-Semi-Furnished Studio- 6-12 Months + Gym +24/7 Security</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,550</span>
+
+                <span class="housing">
+                    367ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Chinatown - East Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282940157" data-repost-of="7025444115">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/west-vancouver-orcaref4481kstunning/7282940157.html" class="result-image gallery" data-ids="3:00q0q_h3cvd5g8SFGz_0kE0dL,3:00z0z_xGmdlS4uzfz_0kE0dL,3:01313_lAyLP3XyWIDz_0kE0dL,3:00b0b_29r6elsE06Uz_0kE0dL,3:00x0x_VoNTwHZkvaz_0kE0dL,3:00n0n_YEmm0si4G5z_0kE0dL,3:00E0E_7epwpmWv9oBz_0kE0dL,3:00s0s_8oBDzPJuXlz_0kE0dL,3:01212_5EXrQ1ecZY1z_0kE0dL,3:00V0V_8ygNXWp5k8kz_0kE0dL,3:01111_8oYunZoW9trz_0kE0dL,3:00L0L_9CPsRFlpdyEz_0kE0dL,3:00U0U_36NU5YLJXsPz_0kE0dL,3:00x0x_TxEY0OqsYEz_0kE0dL,3:00Q0Q_8K028wo6XdEz_0kE0dL,3:00y0y_aO78Mod7crUz_0kE0dL,3:00Y0Y_5KP6ReQk4OOz_0kE0dL,3:00m0m_1iKL3ASIQAoz_0kE0dL,3:01010_6JUqCUboSctz_0kE0dL,3:00C0C_d6f2ISjfl5kz_0kE0dL,3:00E0E_8fFwYDe1JC3z_0kE0dL,3:00u0u_eRhN42DYwzHz_0kE0dL,3:00b0b_lzRUJM7vMyqz_0kE0dL,3:00r0r_g2faPaO2GKBz_0kE0dL">
+                <span class="result-price">$14,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 7200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00q0q_h3cvd5g8SFGz_0kE0dL_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="22" style="width: 300px; left: -6600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="23" style="width: 300px; left: -6900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 24</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:51" title="Thu 25 Feb 05:51:38 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/west-vancouver-orcaref4481kstunning/7282940157.html" data-id="7282940157" class="result-title hdrlnk" id="postid_7282940157">(ORCA_REF#4481K)***Stunning  Luxurious 6 Bed/7 Bath House</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$14,000</span>
+
+                <span class="housing">
+                    6br -
+                    7844ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Caulfield)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7276279569">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-1br-suite-in-fraserhood/7276279569.html" class="result-image gallery" data-ids="3:00V0V_5zu7JZEc1Jpz_0CI0t2,3:00z0z_elD7tk44qfvz_0CI0t2,3:00p0p_dDIu5XBxofUz_0CI0t2,3:00D0D_ipFshX7931Vz_0CI0t2,3:01414_cDduZfZSOLoz_0CI0s3,3:00y0y_gtvJ0WPtLIZz_0CI0t2,3:00707_3ECsEMltD0Zz_0CI0t2,3:00g0g_5WBGX9oZYc3z_0bi0gY">
+                <span class="result-price">$1,400</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00V0V_5zu7JZEc1Jpz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:50" title="Thu 25 Feb 05:50:49 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-1br-suite-in-fraserhood/7276279569.html" data-id="7276279569" class="result-title hdrlnk" id="postid_7276279569">1BR suite in Fraserhood</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,400</span>
+
+                <span class="housing">
+                    1br -
+                    600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281442198">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-br-899ft2-unfurnished-brentwood/7281442198.html" class="result-image gallery" data-ids="3:00m0m_bmjHjKDaZQiz_0pm06w,3:00505_b099vMWQKRBz_0pO0bC,3:00303_15hMZItixE8z_07K05O,3:00R0R_5zjMHgiNO7mz_0nG06o,3:00E0E_22u5CpNyk7qz_0pO0cC,3:00R0R_iCUuEkN6BRsz_07K05O">
+                <span class="result-price">$2,300</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_bmjHjKDaZQiz_0pm06w_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 6</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:50" title="Thu 25 Feb 05:50:40 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-br-899ft2-unfurnished-brentwood/7281442198.html" data-id="7281442198" class="result-title hdrlnk" id="postid_7281442198">$2,300 / 2br - 899ft2 - Unfurnished Brentwood 2 Bedroom Condo for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,300</span>
+
+                <span class="housing">
+                    2br -
+                    899ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Brentwood)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279724421" data-repost-of="7068560869">
+
+        <a href="https://vancouver.craigslist.org/pml/apa/d/pitt-meadows-solaris-at-meadows-gate/7279724421.html" class="result-image gallery" data-ids="3:00D0D_eiKMOI4vmC0_0ak07K,3:00G0G_3UyvAjRGHdyz_0CI0pO,3:01616_5gIuobiMheU_0ve0kM,3:00909_6T0pnPprocEz_0ve0kM,3:00909_6T0pnPprocEz_0ve0kM,3:00E0E_bgV2Cz99vnzz_0zu0t2,3:00d0d_2o18Gw5tpN2_0ve0kM,3:00u0u_1IbH1btrWP8z_0ww0oo,3:00O0O_eZjgUkkHJIgz_0ww0oo,3:00b0b_bdjdeAFhUzUz_0ww0oo,3:00k0k_dI5dlfegNRXz_0ww0oo,3:01414_8fYPUpVL9HEz_0ww0oo,3:00s0s_ktfgCjQLXDFz_0kM0ve,3:00n0n_dBWTMsZ9LuBz_0ve0kM,3:00303_cJyLNFr8axQz_0kM0ve">
+                <span class="result-price">$2,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00D0D_eiKMOI4vmC0_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:50" title="Thu 25 Feb 05:50:24 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/pml/apa/d/pitt-meadows-solaris-at-meadows-gate/7279724421.html" data-id="7279724421" class="result-title hdrlnk" id="postid_7279724421">Solaris at Meadows Gate Village - The Two Plus Den with Amazing Views!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,100</span>
+
+                <span class="housing">
+                    2br -
+                    1038ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Pitt Meadows)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7276127366">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-marpole/7276127366.html" class="result-image gallery" data-ids="3:00k0k_1VkDsoGqkzz_0jm0pO,3:00L0L_lzUP7rboLh3z_0jm0pO,3:00X0X_7hfLhncH8Pxz_0jm0pO,3:00I0I_lL5Nbtp3BaBz_0jm0pO,3:00r0r_3BtMKzlApP8z_0jm0pO,3:00404_jH4JrKtrBQHz_0jm0pO">
+                <span class="result-price">$2,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00k0k_1VkDsoGqkzz_0jm0pO_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 6</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:49" title="Thu 25 Feb 05:49:03 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-marpole/7276127366.html" data-id="7276127366" class="result-title hdrlnk" id="postid_7276127366">One Bedroom Apartment Marpole MC2 Furnished</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,100</span>
+
+                <span class="housing">
+                    1br -
+                    450ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7276665515">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-coal-harbour-bedroom-plus-den/7276665515.html" class="result-image gallery" data-ids="3:00O0O_iDrAkvMpXUTz_0ak07K,3:00j0j_1D66bBpfPdXz_0af0ft,3:00R0R_cz71SNKKWjLz_0qk0jK,3:00f0f_3itvw7lxlmuz_0qk0jK,3:00C0C_fGuJgLTchdgz_0jK0qk,3:00Q0Q_jGoMVvAHmsuz_0jK0qk,3:00K0K_c5zhU3IMUytz_0jK0qk,3:01010_81WgfqTK7m3z_0jK0qk,3:00h0h_gzokaX72ZCbz_0kE0dG,3:00b0b_jilrXHXGRK6z_0kE0dG,3:00L0L_apxaVKlvZVtz_0kE0dG,3:00303_d8S6fLz550Uz_0CI0ml">
+                <span class="result-price">$1,850</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00O0O_iDrAkvMpXUTz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:45" title="Thu 25 Feb 05:45:41 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-coal-harbour-bedroom-plus-den/7276665515.html" data-id="7276665515" class="result-title hdrlnk" id="postid_7276665515">Coal Harbour - 1 bedroom plus den suite for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    589ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7268770929">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-highgate-bedroom-bathroom/7268770929.html" class="result-image gallery" data-ids="3:00Y0Y_jIxyEdWP2P3z_0ak07K,3:00b0b_dRGc2M56Axpz_0ak07K,3:00v0v_6IZ3YQbX0Hvz_0cU09G,3:00505_1xT2OhPxA5Iz_0cU09G,3:00j0j_gy1AChFsYmez_0ak07K,3:01616_g0OG4DTBxyyz_0hq0ne,3:00A0A_fL8MgOahKuVz_0ne0hq,3:00F0F_bQJRPL33B7jz_0ak07K,3:00K0K_b1ZGW1TdrZYz_0ak07K">
+                <span class="result-price">$1,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00Y0Y_jIxyEdWP2P3z_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:45" title="Thu 25 Feb 05:45:00 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-highgate-bedroom-bathroom/7268770929.html" data-id="7268770929" class="result-title hdrlnk" id="postid_7268770929">Highgate - 2 bedroom/2 bathroom townhouse for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,800</span>
+
+                <span class="housing">
+                    2br -
+                    900ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Burnaby)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7278118789">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-olympic-village-furnished-bed/7278118789.html" class="result-image gallery" data-ids="3:00S0S_2YL3YFHQcDz_0kE0dL,3:01515_afLhi8TVP0pz_0kE0dL,3:00O0O_5y1CSUnnOXWz_0kE0dL,3:01616_4IrJPYnqfP6z_0kE0dL,3:00404_lUlv6yGqV8Fz_0kE0dL,3:00l0l_7s3PAai1pXYz_0kE0dL,3:00X0X_3sBdZc5NlXOz_0kE0dL,3:00C0C_9sd3gni9yTPz_0kE0dL,3:00V0V_EQfJ4WG9Fjz_0kE0dL">
+                <span class="result-price">$1,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00S0S_2YL3YFHQcDz_0kE0dL_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:44" title="Thu 25 Feb 05:44:27 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-olympic-village-furnished-bed/7278118789.html" data-id="7278118789" class="result-title hdrlnk" id="postid_7278118789">Olympic village furnished 1 bed suite for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,800</span>
+
+                <span class="housing">
+                    1br -
+                    450ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282941706">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-chic-modern-laneway-house/7282941706.html" class="result-image gallery" data-ids="3:00r0r_bbq5Jehfg30z_03S05a,3:00p0p_gFKZnmF8mM8z_07K0ak,3:00a0a_gQi9gTBhGdgz_07K0ak,3:00j0j_RPTjVAhJLkz_07K0ak,3:00P0P_4EKYR63aBIsz_0ak05O,3:00Y0Y_5uF237g5aozz_07K0ak,3:00u0u_fViCH4G7Jclz_07K0ak,3:00000_kA3nvt0F71Gz_07K0ak,3:00D0D_AEF3XfYCGaz_0gw0co,3:00W0W_eLEuPzqJYnzz_0jm0ex,3:00g0g_5KtD0bFQk77z_07K0ak">
+                <span class="result-price">$2,300</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00r0r_bbq5Jehfg30z_03S05a_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:44" title="Thu 25 Feb 05:44:14 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-chic-modern-laneway-house/7282941706.html" data-id="7282941706" class="result-title hdrlnk" id="postid_7282941706">Chic modern Laneway house</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,300</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282941521">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-basement-suite/7282941521.html" class="result-image gallery" data-ids="3:00606_bGuuZRjrOztz_0ak07K,3:00Q0Q_cHpC17vTqBIz_0ak07K,3:00R0R_8OwB0IMy2iEz_0ak07K,3:00R0R_8JjY2Fpcz7fz_07K0ak,3:00F0F_idkXgCdY65lz_0ak07K,3:00707_30JzEdRhkmMz_0ak07K,3:00707_aKWI04MnB4Yz_0ak07K,3:00z0z_fuItGih9Uufz_0ak07K,3:00U0U_lHbp3485f9Zz_07K0ak,3:00S0S_d9Ptvhfqww3z_07K0ak,3:00H0H_5oRASgIeOXMz_0ak07K,3:00Z0Z_knPsP20DwtBz_07K0ak,3:00m0m_7L8sdPK9f5Lz_0ak07K,3:00v0v_dKlM30w16f4z_0ak07K,3:00l0l_1LwIysXvXrz_07K0ak">
+                <span class="result-price">$1,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00606_bGuuZRjrOztz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:43" title="Thu 25 Feb 05:43:43 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-basement-suite/7282941521.html" data-id="7282941521" class="result-title hdrlnk" id="postid_7282941521">3 Bedroom basement suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,500</span>
+
+                <span class="housing">
+                    3br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281896829">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bright-and-spacious-kits/7281896829.html" class="result-image gallery" data-ids="3:00w0w_eyw3GCRN4TSz_0lM0t2,3:00Q0Q_lUPmeUMfSRgz_0lM0t2,3:00O0O_3ERFmnG4RUqz_0cU09G,3:01414_ag5DzvxI2wz_0gw0co,3:00Z0Z_8xPR4aaBHUWz_0lM0t2,3:00x0x_a9f96XqVnB0z_0jm0pO,3:00s0s_bhrDvcGfZbGz_0lM0t2,3:00s0s_hfaNazj9qdYz_0lM0t2,3:00E0E_cQadvljgXJaz_0lM0t2,3:00U0U_hhY4aDlryBZz_0lM0t2,3:00303_ifdAXKQxzvDz_0lM0t2,3:00U0U_ap4e1nZx4mfz_0jm0pO,3:00j0j_sxDSt2vLugz_0lM0t2,3:01010_a58qg4Sh0Asz_0CI0t2,3:00707_go90GP8h4Sez_0t20CI,3:00b0b_94SLfsavKAgz_0t20CI">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00w0w_eyw3GCRN4TSz_0lM0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 16</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:43" title="Thu 25 Feb 05:43:12 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bright-and-spacious-kits/7281896829.html" data-id="7281896829" class="result-title hdrlnk" id="postid_7281896829">Bright and Spacious Kits 2 Bedroom +Den Garden Suite , Great Location</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                    1000ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Kitsilano)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282937079" data-repost-of="7269900332">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-ground-floor-suite/7282937079.html" class="result-image gallery" data-ids="3:01616_3ZgMfAU09nPz_0pO0cx"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01616_3ZgMfAU09nPz_0pO0cx_300x300.jpg">
+                <span class="result-price">$1,400</span>
+        </a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:43" title="Thu 25 Feb 05:43:01 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-ground-floor-suite/7282937079.html" data-id="7282937079" class="result-title hdrlnk" id="postid_7282937079">2 BEDROOM GROUND FLOOR  SUITE UTILITIES INCLUDED</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,400</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (NANAIMO &amp;  55TH AVE VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281422416">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-entire-house-bedrooms/7281422416.html" class="result-image gallery" data-ids="3:00404_fSCzHhNueIvz_0CI0t2,3:00V0V_2JuvHja0Y3Mz_0CI0fY,3:00k0k_lHtcFFew4jPz_0CI0t2,3:01111_iSaiO9T6XR7z_0CI0t2,3:00m0m_2dwDgH2Mbq2z_0CI0gK,3:01414_8HXl3i7qQkfz_0t20CI,3:00404_6w4VBICDaGXz_0CI0h6,3:00F0F_bqZ2Dh52mQ2z_0t20CI,3:01414_dS5XVwNFQgkz_0CI0gK,3:00I0I_1L4krWAirP4z_0CI0eR,3:00Y0Y_1WwJA4VHDJDz_0Bm0CI,3:00C0C_koA0GtQSW3Jz_0CI0k4,3:00H0H_5cf83WV1U4pz_0t20CI,3:01717_kgaVHQHeAm3z_0t20CI,3:00Q0Q_iT3dBLH5Mj8z_0CI0t2,3:00R0R_7HWgv1BgA01z_0CI0ev,3:00N0N_53u6eRjKfXZz_0CI0iD">
+                <span class="result-price">$3,300</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00404_fSCzHhNueIvz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 17</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:42" title="Thu 25 Feb 05:42:59 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-entire-house-bedrooms/7281422416.html" data-id="7281422416" class="result-title hdrlnk" id="postid_7281422416">ENTIRE HOUSE - 3 BEDROOMS + 3 WASHROOMS + 1 LOFT + 1 DEN</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,300</span>
+
+                <span class="housing">
+                    3br -
+                    1500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281727055" data-repost-of="7104601810">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/white-rock-bedroom-main-floor-2-block/7281727055.html" class="result-image gallery" data-ids="3:00k0k_dZVUATcxYlYz_0CI0t2,3:00z0z_4rVxE45bTK8z_0CI0t2,3:00d0d_63XjODW3mctz_0CI0t2,3:00T0T_aHR6H4FdraRz_0CI0t2,3:00I0I_e0nECY3eym2z_0CI0t2,3:00Q0Q_2YHHcWE9Xp7z_0CI0t2,3:00M0M_aM6fkNR2VEIz_0t20CI,3:01111_23eHMphThzGz_0CI0t2,3:00505_3MiKqv5nG9Bz_0CI0sR,3:00f0f_6g7O391Uq2Cz_0CI0o6,3:00m0m_i91rZxWoTVAz_0k10t2,3:00F0F_aGp7dvMp0aYz_0CI0t2,3:00a0a_vozlYN0y9qz_0x20oM,3:01111_alNX0cpUJ8nz_0CI0t2,3:00S0S_lU7rjxjYrBcz_0CI0qJ,3:00707_fyHPwCVQ7Hnz_0t20CI,3:00g0g_1qZPEtEsPLYz_0t20CI">
+                <span class="result-price">$2,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00k0k_dZVUATcxYlYz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 17</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:41" title="Thu 25 Feb 05:41:59 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/white-rock-bedroom-main-floor-2-block/7281727055.html" data-id="7281727055" class="result-title hdrlnk" id="postid_7281727055">3 BEDROOM, MAIN FLOOR, 1/2 BLOCK FROM THE BEACH, APRIL 1ST, PETS OK!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,500</span>
+
+                <span class="housing">
+                    3br -
+                </span>
+
+                <span class="result-hood"> (WHITE ROCK)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281715387" data-repost-of="7104601810">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/white-rock-bedroom-main-floor-2-block/7281715387.html" class="result-image gallery" data-ids="3:00z0z_4rVxE45bTK8z_0CI0t2,3:00k0k_dZVUATcxYlYz_0CI0t2,3:00d0d_63XjODW3mctz_0CI0t2,3:00T0T_aHR6H4FdraRz_0CI0t2,3:00I0I_e0nECY3eym2z_0CI0t2,3:00Q0Q_2YHHcWE9Xp7z_0CI0t2,3:00M0M_aM6fkNR2VEIz_0t20CI,3:01111_23eHMphThzGz_0CI0t2,3:00505_3MiKqv5nG9Bz_0CI0sR,3:00f0f_6g7O391Uq2Cz_0CI0o6,3:00S0S_lU7rjxjYrBcz_0CI0qJ,3:00r0r_28xTN4LCY3Xz_0t20CI">
+                <span class="result-price">$2,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00z0z_4rVxE45bTK8z_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:41" title="Thu 25 Feb 05:41:36 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/white-rock-bedroom-main-floor-2-block/7281715387.html" data-id="7281715387" class="result-title hdrlnk" id="postid_7281715387">2 BEDROOM, MAIN FLOOR, 1/2 BLOCK FROM THE BEACH, APRIL 1ST, PETS OK!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,100</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (WHITE ROCK)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7276177688">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-large-main-floor-bedroom-laundry/7276177688.html" class="result-image gallery" data-ids="3:00E0E_iK9ZkvuuIskz_0jm0pO,3:00909_f8uXzF1Ht1tz_0pO0jm,3:00X0X_byXk7Rn0HHpz_0jm0pO,3:00000_6LSQyyrC8gOz_0jm0pO,3:00c0c_gMxpvMyemqaz_0jm0pO">
+                <span class="result-price">$1,400</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00E0E_iK9ZkvuuIskz_0jm0pO_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:41" title="Thu 25 Feb 05:41:34 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-large-main-floor-bedroom-laundry/7276177688.html" data-id="7276177688" class="result-title hdrlnk" id="postid_7276177688">LARGE MAIN FLOOR 2 BEDROOM W/LAUNDRY WASHER</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,400</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (NETWON SURREY)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282916470" data-repost-of="7020201563">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-greenwood-gardens-bedroom/7282916470.html" class="result-image gallery" data-ids="3:00303_2usr4ri3hel_06s04j,3:00G0G_di8LCWw1Sxv_0gw0co,3:01414_1cBtpGZikRf_0gw0co,3:00707_lhvmBrqNxfT_0gw0co,3:00L0L_39nsBU7jIR_0gw0co,3:00D0D_lnimFeKieBR_0gw0co,3:00w0w_ixtKmcw5K2M_0gw0co">
+                <span class="result-price">$1,350</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00303_2usr4ri3hel_06s04j_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 7</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:40" title="Thu 25 Feb 05:40:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-greenwood-gardens-bedroom/7282916470.html" data-id="7282916470" class="result-title hdrlnk" id="postid_7282916470">Greenwood Gardens - 1 bedroom apartment</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,350</span>
+
+                <span class="housing">
+                    1br -
+                    662ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Surrey, Guilford)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7270813447" data-repost-of="6004782904">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/beautiful-one-bedroom-garden-suite/7270813447.html" class="result-image gallery" data-ids="3:00K0K_klNHDRrLKMlz_0CI0sV,3:00m0m_4ZJUyP9uuMhz_0CI0sV,3:01111_g2NDNweeMs1z_0CI0t2,3:00H0H_6pYt7qBeb4Dz_0CI0t2,3:00k0k_3cqHjAITKRqz_0CI0t2,3:01414_i6PrqZWWWrmz_0CI0t2,3:00h0h_eqsYluOY00Vz_0CI0t2,3:00B0B_eAsqXNeQaJLz_0CI0t2,3:00c0c_30UPWFaRPVhz_0CI0t2">
+                <span class="result-price">$1,695</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00K0K_klNHDRrLKMlz_0CI0sV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:40" title="Thu 25 Feb 05:40:49 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/beautiful-one-bedroom-garden-suite/7270813447.html" data-id="7270813447" class="result-title hdrlnk" id="postid_7270813447">Beautiful One Bedroom Garden Suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,695</span>
+
+                <span class="housing">
+                    1br -
+                    585ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Point Grey)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7269936652">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-lower-west-bedroom-suite-for-rent/7269936652.html" class="result-image gallery" data-ids="3:01212_1RXA1iwgzPEz_0ak07K,3:00202_fDZGxIaIMbhz_0ak07K,3:00R0R_h3RiAQJJTDiz_0ak07K,3:00101_35oPc7pVtDrz_0ak07K,3:00000_6nR4ad3ZHTqz_0ak07K,3:00V0V_5orxCVPhh39z_0ak07K,3:00909_ivbZ73ZDxdpz_0ak07K,3:01616_lefiAHhlbwXz_0ak07K">
+                <span class="result-price">$1,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01212_1RXA1iwgzPEz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:39" title="Thu 25 Feb 05:39:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-lower-west-bedroom-suite-for-rent/7269936652.html" data-id="7269936652" class="result-title hdrlnk" id="postid_7269936652">1 bedroom suite for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,100</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (Surrey)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282940221" data-repost-of="6651177845">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-lovely-well-laid-out-concord/7282940221.html" class="result-image gallery" data-ids="3:00606_hHuIHl8aWh8z_0lM0t2,3:00X0X_e59zslkA7Olz_0CI0sV,3:00B0B_8FBbUCpPSmSz_0CI0sV,3:00A0A_kX9NV48XqLIz_0CI0sV,3:00j0j_2hRfJ1JuPM5z_0lG0t2,3:01414_h68oXUfITbBz_0lG0t2,3:00D0D_gPfnFQiPFiNz_0lG0t2,3:00m0m_jHjyExUs6Pnz_0js0lP">
+                <span class="result-price">$2,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00606_hHuIHl8aWh8z_0lM0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:39" title="Thu 25 Feb 05:39:51 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-lovely-well-laid-out-concord/7282940221.html" data-id="7282940221" class="result-title hdrlnk" id="postid_7282940221">Lovely &amp; Well Laid Out Concord Pacific Condo @ The Cosmo</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,100</span>
+
+                <span class="housing">
+                    1br -
+                    687ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (161 W. Georgia St., Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282940192">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-new-1bed-1bath-parking-storage/7282940192.html" class="result-image gallery" data-ids="3:00E0E_7938gmJEn2Pz_0CI0t2,3:00m0m_cApct5nSWdEz_0t20CI,3:01616_bHvhyRBf36xz_0CI0t2,3:00b0b_4n3SBu5i7vrz_0t20CI,3:00Z0Z_k6PGUxUxMLPz_0t20CI,3:00101_7xG44g1ufNJz_0t20CI,3:01616_9k0nyza6ynEz_0CI0t2,3:00606_kLkCxbrlxHpz_0CI0t2,3:00202_92NpJB21Au6z_0t20CI,3:01313_5LsY6RhANGWz_0t20CI,3:00505_65tKTgO31T0z_0CI0t2">
+                <span class="result-price">$1,850</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00E0E_7938gmJEn2Pz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:39" title="Thu 25 Feb 05:39:43 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-new-1bed-1bath-parking-storage/7282940192.html" data-id="7282940192" class="result-title hdrlnk" id="postid_7282940192">NEW 1Bed/1Bath /Parking/ Storage Locker (Amazing Brentwood)</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    542ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Burnaby)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281162369">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/new-westminster-northeast-modo-car/7281162369.html" class="result-image gallery" data-ids="3:00X0X_AP7J6q4hiQz_09a06a,3:00l0l_i77r6hSb8eMz_0io0bh,3:00t0t_csLg1BhmmGDz_0io0bN,3:00i0i_6Z1d6k8TXisz_0io0cf,3:00000_5kStA3dKGCcz_0io0aN,3:00x0x_2ALfBlJqOSqz_0io0at,3:00P0P_h2qWeDiAXmAz_08v05v,3:00T0T_5QjTlXqzjXYz_08v05v">
+                <span class="result-price">$1,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00X0X_AP7J6q4hiQz_09a06a_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:39" title="Thu 25 Feb 05:39:42 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/new-westminster-northeast-modo-car/7281162369.html" data-id="7281162369" class="result-title hdrlnk" id="postid_7281162369">Modo car-share program, Storage facility (additional fee), Elevator</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,500</span>
+
+                <span class="housing">
+                    420ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (New Westminster)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7277393276">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-two-bedrooms-in-upper-floor-of/7277393276.html" class="result-image gallery" data-ids="3:00101_bG24xIkhBjXz_0jm0cT,3:00x0x_lG8qYuOOsOgz_0jm0cT,3:00N0N_bV7VQ3aCaxsz_0jm0cT,3:01616_8tK4ddq2fSbz_0jm0ew,3:00q0q_37UWxv7cntqz_0jm0ew,3:00l0l_lmvOtMBAV1Kz_0jm0cT,3:00k0k_11mqiaVpGwqz_0jm0ew,3:00G0G_erjn0iiM9vwz_0jm0ew,3:00c0c_l3BT8tXmOCoz_0jm0cT,3:00c0c_696XlzzXa7Zz_0ak06T,3:00w0w_7eaYOMmnmBXz_0gP0o6,3:00A0A_fEAIjE9iUSiz_0CI0t2">
+                <span class="result-price">$1,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00101_bG24xIkhBjXz_0jm0cT_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:38" title="Thu 25 Feb 05:38:53 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-two-bedrooms-in-upper-floor-of/7277393276.html" data-id="7277393276" class="result-title hdrlnk" id="postid_7277393276">Two bedrooms in upper floor of house</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,800</span>
+
+                <span class="housing">
+                    2br -
+                    1600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (North Burnaby)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282939697">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-basement-suite/7282939697.html" class="result-image gallery" data-ids="3:00g0g_lQDYbPBzCSVz_07K0ak,3:00W0W_dV5bEqSa5vcz_0ak07K,3:00l0l_coY6p2u8N3lz_0ak07K,3:00i0i_inm3pLqawIXz_0ak07K,3:01717_biLkJYGNPsDz_0ak07K,3:00909_gD3ntIcAqyqz_0ak07K,3:00202_aiF5UaBR5uBz_0ak07K,3:00D0D_d22Onm51v0Pz_0ak07K,3:00Q0Q_iIqYxtW59Prz_07K0ak,3:00x0x_8hNGQn8i8LEz_07K0ak,3:01313_dzIelS7Kvzzz_07K0ak">
+                <span class="result-price">$1,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00g0g_lQDYbPBzCSVz_07K0ak_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:38" title="Thu 25 Feb 05:38:19 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-basement-suite/7282939697.html" data-id="7282939697" class="result-title hdrlnk" id="postid_7282939697">2 Bedroom basement suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,800</span>
+
+                <span class="housing">
+                    2br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279540816">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-suite-unfurnished/7279540816.html" class="result-image gallery" data-ids="3:00j0j_iDKPVY7qHBCz_0t20lM,3:00808_i9BonMYACqUz_0ww0oo,3:00D0D_d5kyucUVZVgz_0ww0oo">
+                <span class="result-price">$1,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00j0j_iDKPVY7qHBCz_0t20lM_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 3</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:38" title="Thu 25 Feb 05:38:03 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-suite-unfurnished/7279540816.html" data-id="7279540816" class="result-title hdrlnk" id="postid_7279540816">1 bedroom suite unfurnished basement in a modern house</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,200</span>
+
+                <span class="housing">
+                    1br -
+                    580ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Renfrew Height , Vancouver East)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7281467112">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-new-bed-bath-ev-parking-at/7281467112.html" class="result-image gallery" data-ids="3:00a0a_9YrLQND8iNbz_0CI0pL,3:00Y0Y_4FhgdRTQpbEz_0CI0pL,3:01111_lmxIYxOv2zqz_0CI0pL,3:00m0m_h7oYXTEaDMiz_0CI0pL,3:00c0c_jW8AvKUcrw4z_0CI0pL,3:00909_9XRgB7Ti1wAz_0CI0pL,3:00K0K_2B1UgRBtc7pz_0CI0pL,3:00b0b_ljC9VCAvADZz_0CI0pL,3:00q0q_krV33zr5kHKz_0CI0pL,3:00t0t_jDdCjQuUM3pz_0CI0pL,3:00o0o_pF77HgX9wez_0CI0pL">
+                <span class="result-price">$2,300</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00a0a_9YrLQND8iNbz_0CI0pL_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:37" title="Thu 25 Feb 05:37:55 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-new-bed-bath-ev-parking-at/7281467112.html" data-id="7281467112" class="result-title hdrlnk" id="postid_7281467112">New 2 Bed 2 Bath + EV Parking at Amazing Brentwood Tower 3</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,300</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Brentwood - Burnaby, BC)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7275258514">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-highrise-condo-for/7275258514.html" class="result-image gallery" data-ids="3:00c0c_6fRLT5DdiG5z_0kE0dL,3:00C0C_7QCexq01GiJz_0g80aI,3:01010_heQytM06i1wz_0ne0hq,3:00C0C_jYki0khMSkmz_0ne0hq,3:00o0o_1UxdjsbjhtJz_0ne0hq,3:00808_f6tfRD30rJbz_0ne0hq,3:00j0j_b29k3uOVgX4z_0ne0hq,3:00O0O_fI93u7u6X4z_0ne0hq,3:00o0o_9MxSBNcqbvzz_0ne0hq,3:00X0X_2QgtgK0psUaz_0ne0hq,3:01616_4pxI4aAPNLMz_0ne0hq,3:00Z0Z_9QHon3n9idz_0hq0ne,3:00N0N_kFvfWg8a2oLz_0ne0hq,3:00707_7yVFZecrFeZz_0ne0hq,3:01313_blzZ0LWeRUDz_0gw0b0">
+                <span class="result-price">$2,900</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00c0c_6fRLT5DdiG5z_0kE0dL_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:36" title="Thu 25 Feb 05:36:28 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-highrise-condo-for/7275258514.html" data-id="7275258514" class="result-title hdrlnk" id="postid_7275258514">2 Bed 2 Bath highrise condo for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,900</span>
+
+                <span class="housing">
+                    2br -
+                    866ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (downtown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7270268663">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-highrise-views/7270268663.html" class="result-image gallery" data-ids="3:00707_akjVAY81dXyz_0ak07K,3:00I0I_antlC3N7Ga4z_0ak07K,3:01010_96usqFXlu14z_0ak07K,3:00y0y_93KBzAowAbiz_0ak07K,3:01515_5p8n2vy0wz4z_0ak07K,3:01010_92v5wykgvqIz_0ak07K,3:00A0A_fAugwE24KSnz_0ak07K,3:00t0t_grJ8CGa5EJmz_0ak07K,3:00z0z_grf9udKiCKkz_0ak07K,3:01515_6dqPMgisiZz_0ak07K,3:00Z0Z_6F0lmU9n4nQz_0ak07K,3:00P0P_gaBZ8ZgJmZjz_0ak07K,3:01515_1pc0RMVJPe9z_0ak07K,3:00W0W_2WZYYQqCwtvz_08C069,3:00B0B_kBegLeRopeKz_0f60i0">
+                <span class="result-price">$2,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00707_akjVAY81dXyz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:36" title="Thu 25 Feb 05:36:22 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bed-bath-highrise-views/7270268663.html" data-id="7270268663" class="result-title hdrlnk" id="postid_7270268663">2 Bed 2 Bath Highrise w/views besides Skytrain</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,500</span>
+
+                <span class="housing">
+                    2br -
+                    769ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Marpole)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279427809" data-repost-of="7277238907">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/tsawwassen-bedroom-condo-for-rent/7279427809.html" class="result-image gallery" data-ids="3:00L0L_35KWNpGQMRrz_0gq0aY,3:00c0c_3l4a0wgpNLLz_0oG0gn,3:00X0X_kUaSLVz1wCSz_0oG0gn,3:00I0I_j6uYVLc895Ez_0oG0gn,3:01616_qZByPAgypjz_0ne0hq,3:00l0l_8ennT7NQcK4z_0ak07K,3:01515_34TciwcoZCSz_0ne0hq,3:01010_6qjzLaBnHc7z_0ne0hq,3:00d0d_loZIanefSmzz_0ak07K,3:00404_bFKNzAlGEatz_0ne0hq,3:00l0l_hQ5kO8w5pmOz_0ne0hq,3:00Q0Q_8EkaXcS2F4pz_0hq0ne,3:00r0r_61C44ynboODz_0ne0hq,3:00b0b_9JEg2sad1Tfz_06707K">
+                <span class="result-price">$1,700</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00L0L_35KWNpGQMRrz_0gq0aY_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 14</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:36" title="Thu 25 Feb 05:36:16 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/tsawwassen-bedroom-condo-for-rent/7279427809.html" data-id="7279427809" class="result-title hdrlnk" id="postid_7279427809">1 Bedroom Condo for Rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,700</span>
+
+                <span class="housing">
+                    1br -
+                    508ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Tsawwassen)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282938949">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-2bedroom-basement-suite-in/7282938949.html" class="result-image gallery" data-ids="3:00808_hVMyMhWbJqxz_0CI0sv,3:00y0y_jsysHg7Tf8Ez_0CI0t2,3:00U0U_jdJhx0Chcaoz_0CI0t2,3:00f0f_2W6MwJHmWGxz_0lM0t2,3:01717_2W6aEo6EjMlz_0CI0t2">
+                <span class="result-price">$1,550</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00808_hVMyMhWbJqxz_0CI0sv_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:36" title="Thu 25 Feb 05:36:12 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-2bedroom-basement-suite-in/7282938949.html" data-id="7282938949" class="result-title hdrlnk" id="postid_7282938949">2Bedroom Basement suite in a new Home Great Location- Langara College</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,550</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Langara College, Fraser &amp; 55th Avenue, Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282938631">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-amazing-brentwood3/7282938631.html" class="result-image gallery" data-ids="3:00000_i9BFZZqWOkUz_0t20CI,3:00X0X_j9kcmjjIOPGz_0CI0t2,3:00a0a_8Y1151iJESSz_0t20CI,3:00v0v_7xs4hLNPw14z_0CI0t2,3:00i0i_2qhBMSjlddHz_0t20CI,3:00Y0Y_fXrdNQu218Cz_0t20CI,3:00E0E_9qlVXVgLVSEz_0t20CI,3:01111_jPNTbpquEBpz_0t20CI,3:00f0f_7tYz6WAuCH3z_0t20CI,3:00p0p_gVM5XVpbRkRz_0t20CI,3:00N0N_lYgX9a3pjOmz_0CI0t2,3:00S0S_6ebcxOqs3Hxz_0t20CI">
+                <span class="result-price">$1,850</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_i9BFZZqWOkUz_0t20CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:35" title="Thu 25 Feb 05:35:17 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-brand-new-amazing-brentwood3/7282938631.html" data-id="7282938631" class="result-title hdrlnk" id="postid_7282938631">BRAND NEW! Amazing Brentwood#3 - 1Br/1Ba/Parking/Storage Locker</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    542ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Burnaby)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7274794422" data-repost-of="7134971811">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-east-two-bedroom-basement-for/7274794422.html" class="result-image gallery" data-ids="3:00s0s_gmC9eKktwxwz_0c60lw,3:00a0a_khna9EKtYUz_0c60lw,3:00G0G_cJYxrjJZdy3z_0c60lw,3:00J0J_etezS06kzcPz_0c60lw">
+                <span class="result-price">$1,400</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00s0s_gmC9eKktwxwz_0c60lw_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-east-two-bedroom-basement-for/7274794422.html" data-id="7274794422" class="result-title hdrlnk" id="postid_7274794422">Two bedroom basement for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,400</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Chimney heights)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7274473402" data-repost-of="7256491593">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-like-new-bedroom-bathroom-den/7274473402.html" class="result-image gallery" data-ids="3:00U0U_eVcff4ggYUBz_0kE0dM,3:00d0d_33BuHkMXUlBz_0CI0t2,3:00c0c_i5iVQphjMTGz_0CI0t2,3:00P0P_j4Ut2aSA8Tez_0CI0t2,3:00b0b_bAe2t9lOlM7z_0CI0t2,3:00u0u_ihcuCYdhpg7z_0CI0t2,3:00W0W_KWLEpJWql1z_0CI0t2,3:00W0W_5HHoTqrAauUz_0CI0t2,3:00J0J_9lmBn0Xq0Duz_0CI0t2,3:00p0p_fGmuD2QFFipz_0lM0t2,3:01616_4XKETY3zlA1z_0CI0t2,3:00Q0Q_50K1sGdnlASz_0CI0t2,3:00U0U_15L7pU4imLxz_0kE0dL,3:00P0P_8aoSvJpdI7hz_0CI0t2,3:01616_aprsuDE5DfIz_0lM0t2,3:00E0E_fU4N1DExrUVz_0lM0t2,3:00v0v_6QoAuzqygMpz_0CI0t2,3:00k0k_dXVv2oVz1gGz_0kE0dM,3:00C0C_5IevLuGWfYXz_0kE0dL,3:00F0F_XM08IGMCC9z_0kE0dL,3:00x0x_X8gysC8wORz_0CI0t2,3:00s0s_fSIlmBmisPbz_0kE0dL,3:00y0y_6l91i7okdcaz_0kE0fu,3:00c0c_idJMacx4209z_0kE0dL">
+                <span class="result-price">$2,300</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 7200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00U0U_eVcff4ggYUBz_0kE0dM_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="22" style="width: 300px; left: -6600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="23" style="width: 300px; left: -6900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 24</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:11 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-like-new-bedroom-bathroom-den/7274473402.html" data-id="7274473402" class="result-title hdrlnk" id="postid_7274473402">Like New 2 Bedroom 2 Bathroom &amp; Den at Shoreline River District</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,300</span>
+
+                <span class="housing">
+                    2br -
+                    980ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7270762644" data-repost-of="6875718749">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-den-parking-at/7270762644.html" class="result-image gallery" data-ids="3:00606_2iWcDpLOVzyz_0ak07K,3:00U0U_bTnzKgbHKbAz_0gw0b0,3:00O0O_g2iPy4F5Bm1z_0CI0t2,3:00M0M_cb7usYFGrC1z_0CH0t2,3:00202_UxH4sSr77hz_0CI0t2,3:00k0k_eBZayRrQHF4z_0lM0t2,3:00808_7gg3edlnTvJz_0CH0t2,3:00J0J_jcYzo0pLjHz_0lM0t2,3:00X0X_kMIhffdC0xyz_0kE0dm,3:00L0L_4atqxehoKmhz_0kE0dL,3:00I0I_gL0TSeozOM9z_0kE0dM">
+                <span class="result-price">$2,100</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00606_2iWcDpLOVzyz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:10 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-den-parking-at/7270762644.html" data-id="7270762644" class="result-title hdrlnk" id="postid_7270762644">One Bedroom &amp; Den w/ Parking at One Pacific</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,100</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (68 Smithe St, Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280302227">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom-den/7280302227.html" class="result-image gallery" data-ids="3:00I0I_4aP6sDcZgzWz_0ww0oo,3:00F0F_lvMnRgeJPeLz_0ww0oo,3:00404_cyd9MWDmWhVz_0ww0oo,3:00606_76syl7UBz2Jz_0ww0oo,3:00T0T_kNydUJ95ijjz_0ww0oo,3:00q0q_izvckdOGD1sz_0ww0oo,3:00F0F_4pGoX76rEQhz_0kE0dL,3:00606_hKGRDLoYpkxz_0lM0t2,3:00i0i_UOq79vW68Jz_0ww0oo,3:00202_fvLsgjhoRxwz_0kE0fu,3:00H0H_28ULlt8e1Hlz_0kE0dL,3:00U0U_8WHVPRiB7fSz_0kE0dL,3:00202_3N7hlkqEcegz_0kE0dL,3:00s0s_69D2YMPGN4nz_0kE0dL,3:00g0g_eGZtKroRm5oz_0ak0fu,3:00707_3hsva2KAKrYz_0kE0dL">
+                <span class="result-price">$2,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00I0I_4aP6sDcZgzWz_0ww0oo_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 16</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:10 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom-den/7280302227.html" data-id="7280302227" class="result-title hdrlnk" id="postid_7280302227">Furnished One Bedroom &amp; Den w/ Parking &amp; Locker at Yaletown Park 2</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7278534774" data-repost-of="7259079835">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-like-new-furnished-one/7278534774.html" class="result-image gallery" data-ids="3:00W0W_5VjgI7vj63Uz_0CI0t2,3:00n0n_1tARjwhFGoGz_0CH0t2,3:00f0f_fmIKZvWNooGz_0CI0t2,3:00404_6CXTpvTBn2cz_0CI0t2,3:00101_hpA42xmdL6Fz_0CH0t2,3:00T0T_3ztvK82pOs5z_0CI0t2,3:00u0u_9ARNwJ6VBJVz_08I08I,3:00u0u_ARgvabBR7lz_08I08I,3:00k0k_8x0vRTgJf0yz_08I08I,3:00U0U_3pP2zKVaNRxz_08I08I,3:00909_hguN06tpM3Cz_08I08I,3:00Z0Z_hXLJ7QxiUIkz_08I08I,3:00202_iaZeBLLZxtkz_08I08I">
+                <span class="result-price">$2,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00W0W_5VjgI7vj63Uz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 13</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:09 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-like-new-furnished-one/7278534774.html" data-id="7278534774" class="result-title hdrlnk" id="postid_7278534774">Like New Furnished One Bedroom &amp; Den with Parking at W1</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Marine Gateway Vancouver West)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7275495072">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/langley-langley-brydon-court-brand-new/7275495072.html" class="result-image gallery" data-ids="3:00Y0Y_jCFgI5M93Giz_0t20t2,3:00C0C_fhMRpgeXE1Rz_0t20t2,3:00l0l_dTBGUwMzNrQz_0t20t2,3:00606_8xVB6fpyUiwz_0t20t2,3:00Q0Q_g8N7PiJoScWz_0t20t2,3:00z0z_bglkx1lTKunz_09G07g,3:00s0s_7LAynu0D0V8z_0t20t2,3:00s0s_5b9591ZurP4z_0t20t2">
+                <span class="result-price">$1,650</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00Y0Y_jCFgI5M93Giz_0t20t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 8</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:34" title="Thu 25 Feb 05:34:03 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/langley-langley-brydon-court-brand-new/7275495072.html" data-id="7275495072" class="result-title hdrlnk" id="postid_7275495072">LANGLEY - BRYDON COURT - BRAND NEW VERY SPACIOUS 1 BEDROOM + DEN!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,650</span>
+
+                <span class="housing">
+                    1br -
+                    700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Langley)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282937959" data-repost-of="7262490395">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautiful-bed-bath-plus/7282937959.html" class="result-image gallery" data-ids="3:00m0m_l8WkQTbH7Erz_0ak06T,3:00r0r_5BwycbpH3z3z_0ak06T,3:00707_7PQNak6zVj5z_0ak06T,3:00O0O_6PqTBmYdVa8z_0ak06T,3:00p0p_6hm2bzT674Gz_0ak06T,3:00D0D_aqyfJGoCuRJz_0ak06S,3:01414_klkHCUcj4PTz_0ak06T,3:00r0r_20StJlburWqz_0ak06T,3:00u0u_iOYjOQBCFGwz_0ak06T,3:00L0L_49fqjghfsbBz_0ak06T,3:00z0z_5UIFQodZZaLz_0ak06T,3:00e0e_405IiisMFf5z_0ak06T,3:01515_lvktQPPwEfrz_0ak06T,3:01515_lvktQPPwEfrz_0ak06T,3:00303_2bDHuu9GNa0z_0ak06T,3:01414_kxakmwaWcJ6z_0ak06T,3:00303_l9BciAEXTBNz_09G07g">
+                <span class="result-price">$3,495</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_l8WkQTbH7Erz_0ak06T_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 17</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:33" title="Thu 25 Feb 05:33:27 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautiful-bed-bath-plus/7282937959.html" data-id="7282937959" class="result-title hdrlnk" id="postid_7282937959">Beautiful 2 Bed, 2 Bath plus Jacuzzi and Private Balcony in Tinseltown</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,495</span>
+
+                <span class="housing">
+                    2br -
+                    840ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Tinseltown-Crosstown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7274076820" data-repost-of="7137608411">
+
+        <a href="https://vancouver.craigslist.org/pml/apa/d/port-coquitlam-north-bright-ground/7274076820.html" class="result-image gallery" data-ids="3:00m0m_arJ0gsbatbcz_0CI0t2,3:00B0B_2HKSUzMOgCQz_0CI0t2,3:00m0m_j0YaImdYEY7z_0CI0t2,3:00404_bhTxhn3Qeacz_0CI0t2,3:00D0D_1W582TxsGb9z_0t20CI,3:00A0A_8AEhVk535bsz_0CI0t2,3:00i0i_b9kx0m9bPJkz_0CI0t2">
+                <span class="result-price">$1,400</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_arJ0gsbatbcz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 7</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:32" title="Thu 25 Feb 05:32:49 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/pml/apa/d/port-coquitlam-north-bright-ground/7274076820.html" data-id="7274076820" class="result-title hdrlnk" id="postid_7274076820">Bright, Ground Level 2 Bedroom Legal Suite in Burke Mountain</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,400</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Coquitlam)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282925614">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-modern-bed-bath-prime/7282925614.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:32" title="Thu 25 Feb 05:32:46 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-modern-bed-bath-prime/7282925614.html" data-id="7282925614" class="result-title hdrlnk" id="postid_7282925614">MODERN 1 bed/1 bath PRIME DOWNTOWN location; available !!!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$850</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (888 Homer St, Vancouver, BC V6B 0H7, Canada)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282937705">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-furnished/7282937705.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:32" title="Thu 25 Feb 05:32:44 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-furnished/7282937705.html" data-id="7282937705" class="result-title hdrlnk" id="postid_7282937705">One bedroom furnished apartment in downtown Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282937617" data-repost-of="7262481779">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-contemporary-bed-bath-with/7282937617.html" class="result-image gallery" data-ids="3:01616_kvPdG5iRBQxz_0gw0co,3:01717_lq5xfxt0yXTz_0gw0co,3:00u0u_bYQWjTQBIjXz_0gw0co,3:00w0w_7i7YXmjI7sXz_0gw0co,3:01414_jy5k3ZssE73z_0gw0co,3:01414_5ro2JvLxNUPz_0gw0co,3:00X0X_4oblRRGd3jJz_0gw0co,3:00l0l_cNJjSelzrQPz_0gw0co,3:00V0V_7XPJo425OEnz_0gw0aN,3:00O0O_aQvIXuiNENJz_0gw0co,3:00i0i_6kxqQSaPcO4z_0gw0bL,3:00C0C_jbcC9kEslsrz_0gw0b4,3:00o0o_4bJ8K9M817Uz_0gw0aU,3:00303_l9BciAEXTBNz_09G07g">
+                <span class="result-price">$2,995</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01616_kvPdG5iRBQxz_0gw0co_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 14</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:32" title="Thu 25 Feb 05:32:28 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-contemporary-bed-bath-with/7282937617.html" data-id="7282937617" class="result-title hdrlnk" id="postid_7282937617">Contemporary 2 Bed, 2 Bath with Spacious Balcony and Stylish Decor</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,995</span>
+
+                <span class="housing">
+                    2br -
+                    950ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Fairview)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282937527">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-main-suite/7282937527.html" class="result-image gallery" data-ids="3:00909_b8E68PB4GHTz_07K0ak,3:00Q0Q_iW61dldIzKzz_0ak07K,3:01515_aeDFvABeXYz_0ak07K,3:00I0I_90aBBYlxrUyz_0ak07K,3:00707_iZM0kSquaqBz_0ak07K,3:00a0a_hAedJ0U8PPgz_0ak07K,3:00p0p_WcqZKmkpBmz_0ak07K,3:00P0P_ghDvfZZYqZmz_0ak07K,3:00I0I_aMGZ0HqnfQLz_0ak07K,3:00k0k_1Has0n2rB38z_0ak07K,3:00g0g_lQDYbPBzCSVz_07K0ak,3:00W0W_dV5bEqSa5vcz_0ak07K,3:00i0i_inm3pLqawIXz_0ak07K,3:01717_biLkJYGNPsDz_0ak07K">
+                <span class="result-price">$2,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00909_b8E68PB4GHTz_07K0ak_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 14</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:32" title="Thu 25 Feb 05:32:15 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-main-suite/7282937527.html" data-id="7282937527" class="result-title hdrlnk" id="postid_7282937527">3 Bedroom Main suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    3br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936878" data-repost-of="7247814599">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-sophisticated-bedroom-plus/7282936878.html" class="result-image gallery" data-ids="3:00v0v_k3oGCZ8MW7jz_0x20oM,3:00H0H_7vo2D764EpRz_0x20oM,3:00E0E_5utebQlGLzBz_0x20oM,3:00n0n_7OTtCUv0um2z_0x20oM,3:00n0n_gjQqV6i5qS6z_0x20oM,3:00D0D_hSIaCz3FIM4_0gw0co,3:00g0g_gmlVMsoA3rP_0gw0co,3:01111_cNSRvHilC8Dz_0x20oM,3:00202_IZhOaY1bcb_0g80aL,3:00C0C_6ze8YZmZoXRz_0x20oM,3:00303_6yUs5hK8xsjz_0x20oM,3:00F0F_6A5WCC1zwdUz_0x20oM,3:01414_k9JPhtjaFNRz_0x20oM,3:00d0d_ejcIsrQ1cMf_0c608t,3:00505_eWGE0Yj6lhOz_0x20oM,3:00202_o7H50i7buy_0bC07g,3:01616_l9BciAEXTBN_09G07g">
+                <span class="result-price">$3,695</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00v0v_k3oGCZ8MW7jz_0x20oM_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 17</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:30" title="Thu 25 Feb 05:30:27 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-sophisticated-bedroom-plus/7282936878.html" data-id="7282936878" class="result-title hdrlnk" id="postid_7282936878">Sophisticated 2 Bedroom Plus Den, 2 Bathroom with Solarium</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,695</span>
+
+                <span class="housing">
+                    2br -
+                    856ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Yaletown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7274756987" data-repost-of="7210091101">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-bedrooms-basement-suite/7274756987.html" class="result-image gallery" data-ids="3:00606_eq8yNlzt1Lgz_0jK0qk,3:01212_kJT7nb88obWz_0jK0qk,3:00808_fCT4KWtRMPVz_0jK0qk,3:00r0r_5aMXSOhPwdHz_0jK0qk,3:01212_7HZeWtrz7JVz_0jK0qk">
+                <span class="result-price">$1,500</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00606_eq8yNlzt1Lgz_0jK0qk_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:30" title="Thu 25 Feb 05:30:07 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-two-bedrooms-basement-suite/7274756987.html" data-id="7274756987" class="result-title hdrlnk" id="postid_7274756987">Two Bedrooms Basement suite East Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,500</span>
+
+                <span class="housing">
+                    2br -
+                    800ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936701">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-bed-den-balcony/7282936701.html" class="result-image gallery" data-ids="3:00x0x_4dDIonKAzaWz_0t20CI,3:00101_dVsaICyGUSBz_0CI0t2,3:00d0d_jp1pFRgV1Shz_0CI0t2,3:00H0H_rGkzVIpRB8z_0lM0t2,3:00q0q_a0LGm9hyhXxz_0gl0t2,3:00f0f_lQabaK2RI7Qz_0qk0jK,3:00j0j_2TnDop0eyTkz_0x20oM,3:00z0z_eEl16VVKj34z_0kE0fu,3:00909_fnICQoKe1Sjz_0fu0kE,3:00v0v_g81iEtPAwfBz_0t20CI,3:01111_kghM0D4BBtgz_0gj0eu">
+                <span class="result-price">$1,870</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00x0x_4dDIonKAzaWz_0t20CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 11</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:30" title="Thu 25 Feb 05:30:01 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-bed-den-balcony/7282936701.html" data-id="7282936701" class="result-title hdrlnk" id="postid_7282936701">Furnished 1 Bed + 1 Den + Balcony * Corner Upper-level unit *Views!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,870</span>
+
+                <span class="housing">
+                    1br -
+                </span>
+
+                <span class="result-hood"> (Downtown Vancouver, 610 Granville St.)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936674">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-view-lower-lonsdale/7282936674.html" class="result-image gallery" data-ids="3:00L0L_7EITsUNLvwsz_0ak06S,3:00j0j_iI6JWxuXJhlz_0ak06S,3:00B0B_4w7VR1s0GmKz_0ak06S,3:00w0w_gq2Nn2kxWOiz_0ak06S,3:00L0L_7EITsUNLvwsz_0ak06S,3:01313_klO0LTYM6nUz_0ak06S,3:00x0x_9REvZaMakr3z_0ak06S,3:00i0i_8X1SmOkIbDyz_0ak06S,3:00L0L_kvs2LeFyP92z_0ak06S,3:00U0U_5hIO9RwND3Az_0ak06S,3:01010_gCvelAie3FPz_0ak06S,3:00L0L_7EITsUNLvwsz_0ak06S">
+                <span class="result-price">$2,375</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00L0L_7EITsUNLvwsz_0ak06S_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:29" title="Thu 25 Feb 05:29:54 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-view-lower-lonsdale/7282936674.html" data-id="7282936674" class="result-title hdrlnk" id="postid_7282936674">View! Lower Lonsdale! 1 Bedroom-Almost Waterfront!-Design Marque Mngmt</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,375</span>
+
+                <span class="housing">
+                    1br -
+                    600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Lower Lonsdale-North Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936531">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-outer-east-mount/7282936531.html" class="result-image gallery" data-ids="3:00g0g_7QeEttXUY5mz_0CI0t2,3:00303_9NrZBhTuxnoz_0CI0t2,3:01111_jLQG7bc9Lipz_0CI0t2,3:00D0D_LYwl92lClMz_0CI0t2,3:00M0M_cYQF1EdpTScz_0CI0t2,3:01111_jLQG7bc9Lipz_0CI0t2">
+                <span class="result-price">$1,239</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00g0g_7QeEttXUY5mz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 6</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:29" title="Thu 25 Feb 05:29:31 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-outer-east-mount/7282936531.html" data-id="7282936531" class="result-title hdrlnk" id="postid_7282936531">Mount Seymour Park Housing Coop ~ 2 &amp; 3 bedroom waitlist is open</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,239</span>
+
+                <span class="housing">
+                    3br -
+                </span>
+
+                <span class="result-hood"> (Parkgate Area)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936461" data-repost-of="7101265840">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-charming-bedroom-corner-suite/7282936461.html" class="result-image gallery" data-ids="3:00M0M_acwJxv8gPZN_0g80c6,3:00K0K_eQokHYYuCVJ_0g80c6,3:00r0r_39AH5XTOTma_0g80c6,3:00j0j_6DTeqINMJQa_0g8094,3:00O0O_oRwM2ffYaa_0g8094,3:00808_jVip8dqLYJm_0g8094,3:00H0H_g19FWRBwcVi_0g8094,3:00x0x_hMWhyaYdpTA_0g8094,3:01616_l9BciAEXTBN_09G07g">
+                <span class="result-price">$2,995</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00M0M_acwJxv8gPZN_0g80c6_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 9</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:29" title="Thu 25 Feb 05:29:18 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-charming-bedroom-corner-suite/7282936461.html" data-id="7282936461" class="result-title hdrlnk" id="postid_7282936461">Charming 2 Bedroom Corner Suite With Views of Water, Mountains, and Ci</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,995</span>
+
+                <span class="housing">
+                    2br -
+                    950ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282919137">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-months-free-rent500-credit/7282919137.html" class="result-image gallery" data-ids="3:01212_gjgsoiQxZWez_0oM0gx,3:00W0W_9487PjGzlEEz_0m30x2,3:00b0b_1jvZIBecvMdz_0m30x2,3:00505_jo6s81vrINGz_0oM0gR,3:00k0k_ggbFm0npxDbz_0m30x2,3:00s0s_e7nfM1OB0Evz_0oM0gy,3:00z0z_cQXLdlGkbCYz_0oM0gx,3:00V0V_kmwViP1t52Az_0oM0gw,3:00M0M_i1Z8ZeOAkZCz_0oM0gx,3:00N0N_64CtNk2rVGAz_0oM0gy,3:00O0O_9FGSZAs1locz_0oM0gx,3:00i0i_jEYfD3UQPxKz_0oM0gx">
+                <span class="result-price">$2,067</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01212_gjgsoiQxZWez_0oM0gx_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:28" title="Thu 25 Feb 05:28:42 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-months-free-rent500-credit/7282919137.html" data-id="7282919137" class="result-title hdrlnk" id="postid_7282919137">2 MONTHS FREE RENT+$500 CREDIT! Newly Renovated West End (1BR/1BA) Pets OK</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,067</span>
+
+                <span class="housing">
+                    1br -
+                    549ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (West End)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936128">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom/7282936128.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:28" title="Thu 25 Feb 05:28:21 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-furnished-one-bedroom/7282936128.html" data-id="7282936128" class="result-title hdrlnk" id="postid_7282936128">Furnished one bedroom apartment in downtown Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,850</span>
+
+                <span class="housing">
+                    1br -
+                    500ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282936045" data-repost-of="7061816108">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-tasteful-bedroom-plus-den-in/7282936045.html" class="result-image gallery" data-ids="1:00b0b_aQ3sz69Wdk7,1:00N0N_3Y3PU7oorhe,1:00N0N_fD8Kr9UYaDV,1:00q0q_1WtRUKtfenr,1:00o0o_bB33H4FsevI,1:00C0C_nzWocOO6AF,1:00T0T_gCFVXQayj7n,1:00X0X_1IKqcAneEbY,1:00101_9UdarGNOEPE,1:00505_dgp924Gmct9,1:00303_7Y8hLthAV5G,1:01414_gkgcM9gnpl2,1:01414_2xJFyK6wdul">
+                <span class="result-price">$5,150</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00b0b_aQ3sz69Wdk7_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 13</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:28" title="Thu 25 Feb 05:28:08 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-tasteful-bedroom-plus-den-in/7282936045.html" data-id="7282936045" class="result-title hdrlnk" id="postid_7282936045">Tasteful 2 Bedroom Plus Den In Phenomenal Location with City Views</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$5,150</span>
+
+                <span class="housing">
+                    2br -
+                    787ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (YALETOWN)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7274871420">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-house-for-rent/7274871420.html" class="result-image gallery" data-ids="3:00j0j_kCZsVIJDFdPz_0t20CI,3:00R0R_3T8n3m6uvJKz_0co0gw,3:00909_5qGLewwdhbaz_0co0gw,3:00q0q_58RhcEdKkuaz_0t20CI,3:00y0y_7myf8RP7HXKz_0t20CI,3:00O0O_jFxUuqZiV5Jz_0t20CI,3:00p0p_cCg8tTmefDbz_0t20CI,3:00P0P_e1Lcc9NXnLfz_0t20CI,3:00404_9j3WOqQBxDfz_0t20CI,3:01717_9EJSFQg4ZLRz_0t20CI,3:00w0w_571c5NI19N4z_0t20CI,3:00b0b_843XWvp5216z_0t20CI,3:00N0N_cX9a9CHRfdGz_0t20CI,3:00b0b_3okH9FedhyZz_0t20CI,3:00606_drWPE49MK8Lz_0t20CI,3:00707_5B9QUIWFWOcz_0t20CI">
+                <span class="result-price">$4,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00j0j_kCZsVIJDFdPz_0t20CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 16</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:27" title="Thu 25 Feb 05:27:27 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-house-for-rent/7274871420.html" data-id="7274871420" class="result-title hdrlnk" id="postid_7274871420">House for rent</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$4,800</span>
+
+                <span class="housing">
+                    7br -
+                </span>
+
+                <span class="result-hood"> (fleetwood)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7271336431" data-repost-of="6701698121">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-laneway-house-for-rent-in/7271336431.html" class="result-image gallery" data-ids="3:00A0A_1veppzkz7Plz_0t20CI,3:01717_1NppR4H0w0wz_0t20CI,3:01717_bXdUBnuD0t1z_0pO0CI,3:00O0O_5AETPEQxZMPz_0pO0CI,3:00A0A_ZB8nArPPIUz_0pO0CI,3:00H0H_5TKxfSx1sRUz_0pO0CI,3:00M0M_8DDQNTXOpq2z_0pO0CI,3:00Q0Q_dMHBIycOQhGz_0pO0CI,3:00N0N_fwYRjmOXQyZz_0pO0CI,3:00c0c_kEHzNibDk9pz_0pO0CI,3:00t0t_1pKwlt5B0GAz_0CI0pO,3:00o0o_5xUliTMZjYKz_0CI0pO">
+                <span class="result-price">$1,750</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00A0A_1veppzkz7Plz_0t20CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:26" title="Thu 25 Feb 05:26:42 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-laneway-house-for-rent-in/7271336431.html" data-id="7271336431" class="result-title hdrlnk" id="postid_7271336431">Laneway House for rent in Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,750</span>
+
+                <span class="housing">
+                    2br -
+                    700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282935529">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/lions-bay-architecturally-designed-howe/7282935529.html" class="result-image gallery" data-ids="3:00g0g_3X5lBYWrG3Pz_0ak07K,3:00909_6Ipi7113tjAz_0ak07K,3:01515_4yMKQ2tk4OGz_0ak07K,3:00X0X_3PMA72j1fMQz_0ak07K,3:00f0f_5QUzntgWCsJz_07K0ak,3:01515_eq2mPeWY5Nkz_0ak07K,3:00n0n_6woz6zXmnH3z_07K0ak,3:00H0H_lQZJdK29DM3z_0ak07K,3:00U0U_hxOca1xnt6uz_07K0ak,3:01717_4OL6VDGF8DGz_0ak07K,3:00h0h_gJwMuPUqRZaz_0ak07K,3:01717_2OY1iGeWwLSz_0ak07K,3:00i0i_hLHDUIV9reWz_0ak07K,3:00a0a_bN7w2Fv1dDCz_0ak07K,3:01212_8CLM7ISXyjNz_07K0ak,3:00K0K_gCx5gd2IzH4z_07K0ak,3:00q0q_csR3GvgH0BLz_09z07b,3:00l0l_1K3rddetpgNz_07K0ak,3:00F0F_lOaCA71GlV3z_07K0ak,3:01414_40AZcb85Ewdz_0ak07K,3:01212_8TWNrdcxOAxz_0ak07K,3:00505_9KVa5cn8yq3z_07K0ak,3:00W0W_bXyCrzFmxUbz_0t20CI,3:00p0p_dioBD3D8ZJLz_0oo0ww">
+                <span class="result-price">$4,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 7200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00g0g_3X5lBYWrG3Pz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="22" style="width: 300px; left: -6600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="23" style="width: 300px; left: -6900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 24</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:26" title="Thu 25 Feb 05:26:37 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/lions-bay-architecturally-designed-howe/7282935529.html" data-id="7282935529" class="result-title hdrlnk" id="postid_7282935529">Architecturally designed Howe Sound view home</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$4,000</span>
+
+                <span class="housing">
+                    4br -
+                    3800ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Lions Bay, BC)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282935499" data-repost-of="7114880085">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-spacious-three-bedroom-15/7282935499.html" class="result-image gallery" data-ids="1:00X0X_ejbvByUmgdt,1:00L0L_k0x7yLlxGbi,1:00b0b_hJPdotE38BX,1:00r0r_g2OITya9PuJ,1:00f0f_93HDZlzQMiM,1:00P0P_7E2L44b3PqF,1:00e0e_GL48CzVpw,1:00f0f_3QIe6KhD6a8,1:00505_28cPBYsWVQM,1:00Q0Q_l9gBmj2yEAy,1:00M0M_i5LwGzKXoZr,1:01717_5DQ0orZS5dk,1:00R0R_4mSM2xNzXCo,1:00Q0Q_asmNA3svDM3,1:01414_2xJFyK6wdul">
+                <span class="result-price">$4,895</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00X0X_ejbvByUmgdt_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:26" title="Thu 25 Feb 05:26:32 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-spacious-three-bedroom-15/7282935499.html" data-id="7282935499" class="result-title hdrlnk" id="postid_7282935499">Spacious Three Bedroom 1.5 Bathroom Suite with Private Entrance and Ha</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$4,895</span>
+
+                <span class="housing">
+                    3br -
+                    1050ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282935017" data-repost-of="7192528415">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-southwest-spacious/7282935017.html" class="result-image gallery" data-ids="3:00m0m_8TKsW7jmxmi_0gw0co,3:00k0k_avrodXbc4kF_0gw0co,3:00303_hRSJeIpe5wQ_0gw0co,3:00V0V_loMhko0pyiX_0gw0co,3:00c0c_cUYN48XRNJu_0gw0co,3:00W0W_abCaNfrdd0G_0gw0co,3:00I0I_aOmsGVTxDss_0gw0co,3:01717_fN2Ng9aEG5Q_0gw0co,3:01111_8u9Mn1fQ9OE_0gw0co,3:01616_l9BciAEXTBN_09G07g">
+                <span class="result-price">$2,495</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3000px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_8TKsW7jmxmi_0gw0co_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 10</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:25" title="Thu 25 Feb 05:25:06 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/north-vancouver-southwest-spacious/7282935017.html" data-id="7282935017" class="result-title hdrlnk" id="postid_7282935017">Spacious 2 Bedroom, 1 Bath with Private Yard and Excellent Location</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,495</span>
+
+                <span class="housing">
+                    2br -
+                    800ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (North Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279935579">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-1br-in-2br-suite-look-for/7279935579.html" class="result-image gallery" data-ids="3:00F0F_82qej2GkQ7Bz_09G04B,3:00R0R_3xE1vm5bHjVz_09G07g,3:00z0z_8ajcnnP9bn8z_05r07g,3:00Y0Y_a3ZjrKJ3rH4z_05r07g">
+                <span class="result-price">$600</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00F0F_82qej2GkQ7Bz_09G04B_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 4</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:24" title="Thu 25 Feb 05:24:37 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-1br-in-2br-suite-look-for/7279935579.html" data-id="7279935579" class="result-title hdrlnk" id="postid_7279935579">&nbsp;/ 1br - in a 2br Suite, Look for a Christian Roomate&nbsp;</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$600</span>
+
+
+                <span class="result-hood"> (Surrey)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7270180053">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-downtown-vancouver/7270180053.html" class="result-image gallery" data-ids="3:00000_deY1BiE0GeHz_03y03y,3:00G0G_dbXKbX33iswz_0gw0b0,3:00K0K_7zaU3ZqQnS1z_0gw0b0,3:00c0c_bAM2onX54s3z_01C01d,3:00c0c_lAaC9t9VDTjz_0gw0b0,3:00q0q_lsBOZTki38nz_0gw0b0,3:00i0i_8xtxQUvTRVlz_0gw0b0,3:00505_1JJNY0FWYTQz_0gw0b0,3:00000_NJ0OO4t7AEz_0gw0b0,3:00T0T_lCvF2tZzb09z_0gw0b0,3:00q0q_2S8ELMzk3L5z_0gw0b0,3:00M0M_j86t43yQbo6z_0gw0b0,3:00G0G_579plqOC76Cz_0gw0b0">
+                <span class="result-price">$2,450</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_deY1BiE0GeHz_03y03y_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 13</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:23" title="Thu 25 Feb 05:23:53 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-downtown-vancouver/7270180053.html" data-id="7270180053" class="result-title hdrlnk" id="postid_7270180053">2 Bedroom Downtown Vancouver w/ Parking</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,450</span>
+
+                <span class="housing">
+                    2br -
+                    615ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282911839" data-repost-of="7226606994">
+
+        <a href="https://vancouver.craigslist.org/pml/apa/d/vancouver-3br-upper-house-between-29th/7282911839.html" class="result-image gallery" data-ids="3:00u0u_l40kOyEns4yz_0k20fs,3:00r0r_Dp5TUmGtkPz_0t20CI,3:00H0H_d1dZ3Vn2v5lz_0CI0t2,3:00g0g_cQV7NIxfaJ8z_0CI0t2,3:00x0x_f1s8fc0I1Tkz_0CI0t2,3:00i0i_95Ed31CLgETz_0t20CI,3:00m0m_7YKPlDev6maz_0t20CI,3:00t0t_5iK6SWLrBoUz_0t20CI,3:00L0L_6DrWwQ2hTIEz_0t20CI,3:01010_a4o8qPSWqKOz_0t20CI,3:01414_4omXkIk7w6zz_0t20CI,3:00x0x_9d5ZCDFVUU1z_0t20CI,3:00R0R_eG26VUHIxgPz_0t20CI,3:00O0O_gKA6bZX2xq6z_0t20CI,3:00V0V_aguqOiIErpNz_0t20CI">
+                <span class="result-price">$2,890</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00u0u_l40kOyEns4yz_0k20fs_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:22" title="Thu 25 Feb 05:22:43 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/pml/apa/d/vancouver-3br-upper-house-between-29th/7282911839.html" data-id="7282911839" class="result-title hdrlnk" id="postid_7282911839">3br upper house between 29th &amp; Nanaimo</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,890</span>
+
+                <span class="housing">
+                    3br -
+                    1250ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver East)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282934113" data-repost-of="7229981130">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautiful-bedroom-plus-den/7282934113.html" class="result-image gallery" data-ids="3:00E0E_23W2IOvFV7F_0kE0dL,3:00C0C_eIKWNCkv1Lf_0kE0dL,3:00909_fsaCy5djIXr_0x20oM,3:00A0A_7as9y5ongjp_0kE0dL,3:00g0g_g3dB5UG08PS_0kE0dL,3:00R0R_aVZgr4JLDxq_0kE0dL,3:00A0A_iKzoaE2mRnQ_0kE0dL,3:00B0B_g954cacT10i_0kE0dL,3:01717_1crekInjRFb_0kE0dL,3:00y0y_3cqtResrlMs_0x20oM,3:00c0c_9z5dobOccBF_0kE0dL,3:00T0T_di6lL6xzLG9_0kE0dL,3:00q0q_jLtrLVw0aQm_0kE0dL,3:00V0V_128NuCYag7U_0kE0dL,3:00U0U_8JsMHnUp12t_0x20oM,3:00Y0Y_Cwf04jZKaN_0kE0dL,3:00o0o_dLboBEZYa2X_0kE0dL,3:00l0l_fvlNMkDrNal_0g80aK,3:00G0G_a9LhV2k8DQb_0kE0dL,3:00R0R_2qTpdQNXvZS_0kE0dL,3:01616_l9BciAEXTBN_09G07g">
+                <span class="result-price">$3,495</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6300px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00E0E_23W2IOvFV7F_0kE0dL_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 21</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:22" title="Thu 25 Feb 05:22:30 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautiful-bedroom-plus-den/7282934113.html" data-id="7282934113" class="result-title hdrlnk" id="postid_7282934113">Beautiful 1 Bedroom plus Den, 1 Bathroom with Stylish Furnishings</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,495</span>
+
+                <span class="housing">
+                    1br -
+                    620ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7276057682" data-repost-of="7111161750">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-fully-furnished-bedroom/7276057682.html" class="result-image gallery" data-ids="3:00O0O_7cM71TPjfd9z_0CI0sV,3:00E0E_bvHuPQPx6zhz_05a03S,3:00E0E_87Qu4EoLrwAz_05a03S,3:00q0q_4ifDnwBIEusz_0aj06S,3:00h0h_islwrRncxVpz_0CI0t2,3:00r0r_gTk0KZcGarQz_0x80oK,3:01313_7ba393bGLkfz_0aj06S,3:00v0v_icPek1IK18Kz_0aj06S,3:00W0W_2qW0LxaLOdRz_0CI0sE,3:00101_kQViEvUX5vlz_0aj06S,3:00S0S_k26Y7fCWhQrz_05a03S,3:00U0U_1XZK7gPpQ3bz_05a03S,3:00H0H_bMpOTqq0iVEz_05a03S,3:00707_ht1t7ISevruz_0pO0jm,3:00G0G_gJ0ot6tENv8z_05a03S">
+                <span class="result-price">$2,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00O0O_7cM71TPjfd9z_0CI0sV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:21" title="Thu 25 Feb 05:21:53 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-fully-furnished-bedroom/7276057682.html" data-id="7276057682" class="result-title hdrlnk" id="postid_7276057682">Fully Furnished 1-Bedroom Garden Suite - Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    1br -
+                    600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (East 31st and St. George)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7273670142" data-repost-of="7111164253">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-fully-furnished-bedroom/7273670142.html" class="result-image gallery" data-ids="3:00O0O_7cM71TPjfd9z_0CI0sV,3:00E0E_bvHuPQPx6zhz_05a03S,3:00E0E_87Qu4EoLrwAz_05a03S,3:00q0q_4ifDnwBIEusz_0aj06S,3:00h0h_islwrRncxVpz_0CI0t2,3:00r0r_gTk0KZcGarQz_0x80oK,3:01313_7ba393bGLkfz_0aj06S,3:00v0v_icPek1IK18Kz_0aj06S,3:00W0W_2qW0LxaLOdRz_0CI0sE,3:00101_kQViEvUX5vlz_0aj06S,3:00S0S_k26Y7fCWhQrz_05a03S,3:00U0U_1XZK7gPpQ3bz_05a03S,3:00H0H_bMpOTqq0iVEz_05a03S,3:00707_ht1t7ISevruz_0pO0jm,3:00G0G_gJ0ot6tENv8z_05a03S">
+                <span class="result-price">$2,000</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00O0O_7cM71TPjfd9z_0CI0sV_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:21" title="Thu 25 Feb 05:21:42 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-fully-furnished-bedroom/7273670142.html" data-id="7273670142" class="result-title hdrlnk" id="postid_7273670142">Fully Furnished 1-Bedroom Garden Suite - Vancouver</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,000</span>
+
+                <span class="housing">
+                    1br -
+                    600ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (East 31st and St. George)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7273093733">
+
+        <a href="https://vancouver.craigslist.org/pml/apa/d/coquitlam-downtown-coquitlam-bed-bath/7273093733.html" class="result-image gallery" data-ids="3:00V0V_eMo1WAlPmUAz_0lM0t2,3:00707_6gxN7bt0jIXz_0CI0t2,3:00O0O_8GXt951aY1hz_0CI0t2,3:01010_iJMDLV14zSMz_0lM0t2,3:00i0i_bsdo7x1fDKez_0lM0t2,3:00P0P_gAWWDdqEywIz_0lM0t2,3:00U0U_jAalAxvWkcUz_0lM0t2,3:00S0S_j3w1DB6ilxnz_0lM0t2,3:00g0g_3WnYwj5Prxgz_0lM0t2,3:00j0j_7dpjs68T2KJz_0lM0t2,3:00i0i_lbboOS0rShqz_0lM0t2,3:00A0A_ceN612ya0Eqz_0lM0t2,3:00T0T_lY9hsBwnTMuz_0lM0t2,3:00G0G_3pX2GF19bTEz_0lM0t2,3:00T0T_jkA2O5KOVOvz_0lM0t2,3:00M0M_8u0M9VBcmaBz_0lM0t2,3:00404_5yiiixXNmucz_0lM0t2,3:00C0C_1HpGILLc6LFz_0lM0t2,3:00e0e_j3cQmqENtxLz_0lM0t2">
+                <span class="result-price">$2,195</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00V0V_eMo1WAlPmUAz_0lM0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 19</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:20" title="Thu 25 Feb 05:20:14 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/pml/apa/d/coquitlam-downtown-coquitlam-bed-bath/7273093733.html" data-id="7273093733" class="result-title hdrlnk" id="postid_7273093733">Downtown Coquitlam - 2 Bed, 2 Bath</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,195</span>
+
+                <span class="housing">
+                    2br -
+                    1100ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Downtown Coquitlam)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7268356220" data-repost-of="6634143066">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-duplex-house-for-rent-near-sfu/7268356220.html" class="result-image gallery" data-ids="3:00r0r_9HVmUP6PXRP_0gw09i,3:00x0x_1JvsaYPF5w_0gw09i,3:00707_CuYVr5gmhn_09G05r,3:01212_8gkezaT44ui_09G05r,3:00N0N_oiMZQdsKtb_0gw09i">
+                <span class="result-price">$4,999</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00r0r_9HVmUP6PXRP_0gw09i_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:19" title="Thu 25 Feb 05:19:25 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-duplex-house-for-rent-near-sfu/7268356220.html" data-id="7268356220" class="result-title hdrlnk" id="postid_7268356220">Duplex House for rent near SFU</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$4,999</span>
+
+                <span class="housing">
+                    3br -
+                </span>
+
+                <span class="result-hood"> (BURNABY)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932976" data-repost-of="6971552381">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroomwest-end-downtown/7282932976.html" class="result-image gallery" data-ids="1:00H0H_l99L5d4mpCa,1:00x0x_ln33EsS1fY1,1:00m0m_2qxEgaAFll0,1:00000_2AIyb80UhsB,1:01414_28BuKBuZDKk,3:00V0V_cFBhj25Pb1O_0u00k0,3:00M0M_cX7lSsDvMxy_0u00k0,3:00a0a_4MjSPnn1TnA_0u00k0,3:00D0D_MSazCaBD2A_0u00k0,3:00L0L_7SHlaWqsu9q_0u00k0,3:00m0m_6vEfMSonigY_0u00k0,3:00j0j_4WyQp0TKRWb_0u00k0,3:00d0d_7beb81Ofehu_0u00k0,3:00404_3GfYcrLbxdt_0u00k0,3:01111_kZn3fSUyiWu_0u00k0,3:00J0J_4T8XsmdGfTs_0u00k0,3:00Q0Q_3WonJjjR39N_0u00k0,3:00v0v_ipirbVthsWi_0u00k0,3:00R0R_hdfjPpbceV_0u00k0">
+                <span class="result-price">$2,939</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00H0H_l99L5d4mpCa_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 19</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:19" title="Thu 25 Feb 05:19:21 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroomwest-end-downtown/7282932976.html" data-id="7282932976" class="result-title hdrlnk" id="postid_7282932976">2 BEDROOM,WEST END, DOWNTOWN, STANLEY PARK, FULLY RENOVATED</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,939</span>
+
+                <span class="housing">
+                    2br -
+                    840ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932876" data-repost-of="7269807471">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-luxurious-bedroom-bathroom/7282932876.html" class="result-image gallery" data-ids="3:00T0T_2b9MJ0pd6qBz_0gw0b1,3:00s0s_75pMcy1K3Xrz_0gw0as,3:00O0O_8pgfeUkuFSzz_0gw0b1,3:00q0q_e9s5pd0lB5Jz_0gw0b1,3:00r0r_9OO12ffmTRTz_0gw0b1,3:00202_3tXj69fwV1sz_0gw0ba,3:01111_5YZIWKava6vz_0gw0aq,3:01111_eidRaNOEAUxz_0bB0co,3:00w0w_ipO20tqIiHiz_0d50co,3:00X0X_4SM0aaNxQqlz_0eX0bd,3:00T0T_c9c71qaERgTz_0f90co,3:00303_l9BciAEXTBNz_09G07g">
+                <span class="result-price">$5,495</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00T0T_2b9MJ0pd6qBz_0gw0b1_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:19" title="Thu 25 Feb 05:19:05 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-luxurious-bedroom-bathroom/7282932876.html" data-id="7282932876" class="result-title hdrlnk" id="postid_7282932876">Luxurious 2 Bedroom 2 Bathroom Suite with High Ceilings</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$5,495</span>
+
+                <span class="housing">
+                    2br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Coal Harbour)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932867" data-repost-of="6971552381">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroomwest-end-downtown/7282932867.html" class="result-image gallery" data-ids="1:00H0H_l99L5d4mpCa,1:00x0x_ln33EsS1fY1,1:00m0m_2qxEgaAFll0,1:00000_2AIyb80UhsB,1:01414_28BuKBuZDKk,3:00V0V_cFBhj25Pb1O_0u00k0,3:00M0M_cX7lSsDvMxy_0u00k0,3:00a0a_4MjSPnn1TnA_0u00k0,3:00D0D_MSazCaBD2A_0u00k0,3:00L0L_7SHlaWqsu9q_0u00k0,3:00m0m_6vEfMSonigY_0u00k0,3:00j0j_4WyQp0TKRWb_0u00k0,3:00d0d_7beb81Ofehu_0u00k0,3:00404_3GfYcrLbxdt_0u00k0,3:01111_kZn3fSUyiWu_0u00k0,3:00J0J_4T8XsmdGfTs_0u00k0,3:00Q0Q_3WonJjjR39N_0u00k0,3:00v0v_ipirbVthsWi_0u00k0,3:00R0R_hdfjPpbceV_0u00k0">
+                <span class="result-price">$2,774</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5700px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00H0H_l99L5d4mpCa_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 19</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:19" title="Thu 25 Feb 05:19:03 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroomwest-end-downtown/7282932867.html" data-id="7282932867" class="result-title hdrlnk" id="postid_7282932867">2 BEDROOM,WEST END, DOWNTOWN, STANLEY PARK, FULLY RENOVATED</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,774</span>
+
+                <span class="housing">
+                    2br -
+                    840ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7271342357" data-repost-of="6849703532">
+
+        <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bedroom-1bathroomfurnished/7271342357.html" class="result-image gallery" data-ids="3:01212_gJbJvSTmJnpz_0kE0fu,3:00X0X_aM1bVDd347az_0gw0b1,3:00Q0Q_61VEzf8jNxfz_0ne0hq,3:00y0y_klITloc3DX8z_0kE0fu,3:00c0c_1goiyDQ100Pz_0kE0fu">
+                <span class="result-price">$1,625</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/01212_gJbJvSTmJnpz_0kE0fu_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 5</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:18" title="Thu 25 Feb 05:18:40 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/bnc/apa/d/burnaby-bedroom-1bathroomfurnished/7271342357.html" data-id="7271342357" class="result-title hdrlnk" id="postid_7271342357">$1625 / 1bedroom-1bathroom,furnished/Royal Oak Skytrain /Metrotown</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,625</span>
+
+                <span class="housing">
+                    1br -
+                    545ft<sup>2</sup> -
+                </span>
+
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932618">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-quiet-large-close-to-sfu-sry/7282932618.html" class="result-image gallery" data-ids="3:00m0m_cbgBzAGNvvwz_0gw0b0,3:00M0M_kGYLcSYdd6xz_0gw0b0,3:00H0H_3TbLLmPY84rz_0gw0b0,3:00K0K_kbWv6SMP7rGz_0gw0b0,3:00p0p_elMiT6v7d99z_0gw0b0,3:00A0A_bUJZ0MDkahhz_0gw0b0,3:00M0M_20tlNGVvJAuz_0gw0b0,3:00B0B_eYIfM54OoFnz_0gw0b0,3:00808_471HIssIes4z_0gw0b0,3:00303_cQmN5V6GZUdz_0gw0b0,3:00m0m_bG4F5BM4KbSz_0gw0b0,3:00C0C_f2U3NCwDf5Zz_0gw0b0,3:00d0d_eSoNJswYWoez_0gw0b0,3:01414_cuidTyn5VG9z_0gw0b0,3:00V0V_3j0mKap20aoz_0gw0b0,3:00g0g_fJwtkaJj2Wrz_0gw0b0,3:00H0H_9A7792b2mwMz_0gw0b0,3:00101_l5XzwvhDlm0z_0gw0b0">
+                <span class="result-price">$1,900</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00m0m_cbgBzAGNvvwz_0gw0b0_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:18" title="Thu 25 Feb 05:18:20 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-quiet-large-close-to-sfu-sry/7282932618.html" data-id="7282932618" class="result-title hdrlnk" id="postid_7282932618">☀☀ Quiet, large, close to SFU &amp; SRY Central City Mall</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,900</span>
+
+                <span class="housing">
+                    2br -
+                    765ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (King George &amp; 100 Ave)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7269346792">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7269346792.html" class="result-image gallery" data-ids="3:00000_ZGDBfEuZpoz_04507g,3:01616_7RJS8QtX1E3z_0aT0ew,3:00F0F_eO413sZCZGgz_0kE0fu,3:00G0G_i9gGXNXhveRz_05r07g,3:01616_fqq1vpHo2Ubz_09G07g,3:00909_hwugnUg2rRgz_04507g,3:00Q0Q_kKEKVfOx8yFz_0jm0ew,3:00W0W_kiEoG98Odimz_0lM0t2,3:00I0I_3xAxJw7NQvTz_0CI0t2,3:00101_2V8Gty1Y454z_0lM0t2,3:00C0C_jTj3Gs9ptwwz_0lM0t2,3:01515_biF1kY1I7D8z_0lM0t2,3:01616_jf8UiRNqnTcz_0lM0t2,3:00909_kpTxjTGR5aWz_0lM0t2,3:00707_bvWGl4YbXZKz_0lM0t2,3:00707_TyVhhv4bKPz_04Q03D,3:00n0n_gN7oJvdcgkWz_0fu0kE,3:00000_ftWyyLklAOdz_0lM0t2,3:00u0u_7Cglv8txsP0z_0CI0t2,3:00202_1bq99sRSghmz_0lM0t2,3:00C0C_2vDs4HXuMA1z_0CI0t2,3:00b0b_avmxtvaT2Gfz_0CI0t2">
+                <span class="result-price">$1,595</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_ZGDBfEuZpoz_04507g_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 22</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:18" title="Thu 25 Feb 05:18:02 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7269346792.html" data-id="7269346792" class="result-title hdrlnk" id="postid_7269346792">One Bedroom Apartment/Balcony/West End</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,595</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7270582827">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7270582827.html" class="result-image gallery" data-ids="3:00000_ZGDBfEuZpoz_04507g,3:01616_7RJS8QtX1E3z_0aT0ew,3:00F0F_eO413sZCZGgz_0kE0fu,3:00G0G_i9gGXNXhveRz_05r07g,3:00909_hwugnUg2rRgz_04507g,3:01616_fqq1vpHo2Ubz_09G07g,3:00W0W_kiEoG98Odimz_0lM0t2,3:00I0I_3xAxJw7NQvTz_0CI0t2,3:00C0C_jTj3Gs9ptwwz_0lM0t2,3:01515_biF1kY1I7D8z_0lM0t2,3:00U0U_Q0zNcbvOD6z_0CI0t2,3:01616_jf8UiRNqnTcz_0lM0t2,3:00909_kpTxjTGR5aWz_0lM0t2,3:00707_bvWGl4YbXZKz_0lM0t2,3:00707_TyVhhv4bKPz_04Q03D,3:00n0n_gN7oJvdcgkWz_0fu0kE,3:00000_ftWyyLklAOdz_0lM0t2,3:01010_1NRoMl3teYpz_0lM0t2,3:00f0f_hETZWkat7Shz_0lM0t2,3:00L0L_89KPb5Oni1xz_0CI0t2,3:00Z0Z_9JSLc7tCtmnz_0lM0t2,3:00C0C_2vDs4HXuMA1z_0CI0t2,3:01717_4rpiZFownSXz_0lM0t2">
+                <span class="result-price">$1,595</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6900px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_ZGDBfEuZpoz_04507g_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="22" style="width: 300px; left: -6600px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 23</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:17" title="Thu 25 Feb 05:17:22 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7270582827.html" data-id="7270582827" class="result-title hdrlnk" id="postid_7270582827">One Bedroom Apartment/Balcony/West End</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,595</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280891520">
+
+        <a href="https://vancouver.craigslist.org/nvn/apa/d/coquitlam-best-view-high-rise-building/7280891520.html" class="result-image gallery" data-ids="3:00t0t_4N3LUPAMJpXz_0jm0pO,3:00w0w_i9qsvSY3lugz_0jm0pO,3:00d0d_5DcRTEiZYW7z_0jm0pO,3:00K0K_e6mwa4bBAGez_0jm0pO,3:01313_aopnyA4ZymVz_0jm0pO,3:00101_fuLNfABd7czz_0jm0pO,3:00K0K_3XpcaK5ssoTz_0jm0pO,3:00w0w_ctg3C0awnFXz_0jm0pO,3:00c0c_jghO3sFjEeSz_0jm0pO,3:00t0t_8o0d45TRMffz_0jm0pO,3:00E0E_iarG6MIDWxHz_0jm0pO,3:00V0V_5x7jxQXzwSWz_0jm0pO,3:00b0b_dORHTwIhhakz_0jm0pO,3:00f0f_30EDz7Y12jUz_0jm0pO,3:00P0P_fC54BD0fOxxz_0jm0pO,3:00I0I_biZxf60TNJuz_0jm0pO,3:00101_5Az1cz87JLdz_0jm0pO,3:00303_aX5bX3tcX2jz_0jm0pO">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00t0t_4N3LUPAMJpXz_0jm0pO_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:16" title="Thu 25 Feb 05:16:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/nvn/apa/d/coquitlam-best-view-high-rise-building/7280891520.html" data-id="7280891520" class="result-title hdrlnk" id="postid_7280891520">Best view High Rise Building</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    2br -
+                    620ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (North vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932065">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-kits-dreamrelax-with-nice/7282932065.html" class="result-image gallery" data-ids="3:00M0M_7R3bHL6STN5z_0mO0CI,3:00D0D_53Y79iOIMERz_0hq09y,3:00i0i_4hPaDCYGUroz_0t20CI,3:00K0K_k8PPuFfVNVNz_0t20CI,3:00I0I_gXlcigHbw1Hz_0CI0t2,3:00404_8UL0JPvEtK1z_0t20CI,3:00A0A_9ZiRKyVwfLzz_0t20CI">
+                <span class="result-price">$1,700</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 2100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00M0M_7R3bHL6STN5z_0mO0CI_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 7</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:16" title="Thu 25 Feb 05:16:47 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-kits-dreamrelax-with-nice/7282932065.html" data-id="7282932065" class="result-title hdrlnk" id="postid_7282932065">Kits dream...Relax with a nice view of the ocean from your livingroom</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,700</span>
+
+                <span class="housing">
+                    1br -
+                    900ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Kitsilano)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282932044" data-repost-of="7269179953">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-stunning-bedroom-bathroom/7282932044.html" class="result-image gallery" data-ids="3:00b0b_ajrS2HUQl3Bz_0CI0t2,3:00D0D_j1RcuAaxlK3z_0CI0t2,3:00n0n_6x8UN1XZZn4z_0CI0t2,3:00L0L_2Z1UA7Irsyez_0CI0t2,3:00w0w_kxkIVb6XwZpz_0CI0t2,3:01515_am0Pso8UKx2z_0CI0t2,3:01212_gh46o0pbyAXz_0CI0t2,3:00i0i_hBp9m6AILY0z_0CI0t2,3:00J0J_9wtuUmD08V5z_0CI0t2,3:00C0C_a8sCE8C5aw9z_0CI0t2,3:00C0C_imq1QdbRyr8z_0CI0t2,3:01717_s01Wu6a433z_0CI0t2,3:00s0s_eR9kKjrn164z_0CI0pO,3:00303_efPJZQh72STz_0CI0pO,3:00a0a_5NynnacNIlZz_0CI0pO,3:00f0f_4VbZ1XrwKh7z_0CI0pO,3:00808_9j6Eepfb22Lz_0CI0pO,3:00303_l9BciAEXTBNz_09G07g">
+                <span class="result-price">$3,095</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00b0b_ajrS2HUQl3Bz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:16" title="Thu 25 Feb 05:16:44 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-stunning-bedroom-bathroom/7282932044.html" data-id="7282932044" class="result-title hdrlnk" id="postid_7282932044">Stunning 1 Bedroom, 1 Bathroom with Water Views in Yaletown</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,095</span>
+
+                <span class="housing">
+                    1br -
+                    650ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Yaletown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7272851830">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7272851830.html" class="result-image gallery" data-ids="3:00000_ZGDBfEuZpoz_04507g,3:01616_7RJS8QtX1E3z_0aT0ew,3:00F0F_eO413sZCZGgz_0kE0fu,3:00G0G_i9gGXNXhveRz_05r07g,3:00W0W_2kDkFIlXxdbz_0jm0ew,3:01616_fqq1vpHo2Ubz_09G07g,3:00909_hwugnUg2rRgz_04507g,3:00W0W_kiEoG98Odimz_0lM0t2,3:00I0I_3xAxJw7NQvTz_0CI0t2,3:00C0C_jTj3Gs9ptwwz_0lM0t2,3:01515_biF1kY1I7D8z_0lM0t2,3:00U0U_Q0zNcbvOD6z_0CI0t2,3:00909_kpTxjTGR5aWz_0lM0t2,3:00707_bvWGl4YbXZKz_0lM0t2,3:00707_TyVhhv4bKPz_04Q03D,3:00n0n_gN7oJvdcgkWz_0fu0kE,3:00L0L_5wEtHFWBVslz_0lM0t2,3:00U0U_Q0zNcbvOD6z_0CI0t2">
+                <span class="result-price">$1,595</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00000_ZGDBfEuZpoz_04507g_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:16" title="Thu 25 Feb 05:16:29 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7272851830.html" data-id="7272851830" class="result-title hdrlnk" id="postid_7272851830">One Bedroom Apartment/Balcony/West End</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,595</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282931733">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-laneway-for-rent/7282931733.html" class="result-image gallery" data-ids="3:00404_9ZvsX4UmrM5z_0CI0t2,3:00n0n_lgafZ2snk7Dz_0t20CI,3:01212_4zQPoStDgOfz_0t20CI,3:00x0x_dU0C2rvFMdRz_0CI0t2,3:00t0t_3KFINo6QsfAz_0t20CI,3:00D0D_hkDmBrMALwez_0t20CI,3:00p0p_liJQSb6It5Qz_0t20CI,3:00A0A_hMVn8IuV9Gsz_0t20CI,3:00C0C_GXV3M5lp6tz_0t20CI,3:01111_fj7DDdr96RMz_0CI0t2,3:00t0t_gEpEAzqH1vtz_0CI0t2,3:00L0L_jiqCvIZqvjBz_0t20CI">
+                <span class="result-price">$1,600</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 3600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00404_9ZvsX4UmrM5z_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 12</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:15" title="Thu 25 Feb 05:15:48 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-bedroom-laneway-for-rent/7282931733.html" data-id="7282931733" class="result-title hdrlnk" id="postid_7282931733">2 BEDROOM LANEWAY FOR RENT - $1600</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,600</span>
+
+                <span class="housing">
+                    2br -
+                    700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Vancouver, BC)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7277240491">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7277240491.html" class="result-image gallery" data-ids="3:00p0p_97DXIesNA9sz_0kE0fu,3:00l0l_45iEc1bPhG4z_0kE0fu,3:00a0a_6jElcaBHGhiz_0jm0ew,3:00r0r_ccjLCjx2AChz_05r07g,3:00404_fZD6yNXuAPnz_0jm0ew,3:00z0z_bFsLdqf5lrHz_0jm0ew,3:00000_easW3X6RqBgz_09G07g,3:00a0a_gjK5D1WhaLzz_05r07g,3:00Y0Y_hWKUj9z6CsKz_05r07g,3:01414_9PvNO7DmKWzz_09G07g,3:00p0p_4jsiFvbAjvzz_03904c,3:00k0k_6hjNWBqUbZTz_03904c,3:00u0u_8cgfUnJ2JGXz_04c039,3:00Z0Z_6L8SDhEythTz_0fu0kE,3:00a0a_99IbTwXyLC0z_0kE0fu,3:00404_iVcrL6pdnzUz_0fu0kE">
+                <span class="result-price">$1,635</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00p0p_97DXIesNA9sz_0kE0fu_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 16</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:15" title="Thu 25 Feb 05:15:19 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7277240491.html" data-id="7277240491" class="result-title hdrlnk" id="postid_7277240491">One Bedroom Apartment/Cambie Village</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,635</span>
+
+                <span class="housing">
+                    1br -
+                    750ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282931465" data-repost-of="6958188272">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-custom-build-bed-bath-den/7282931465.html" class="result-image gallery" data-ids="3:00505_2gIeHjSuhakz_0ak07K,3:00505_4NJlW6mbHRCz_0ak07K,3:00909_7jMd1RbIV1Zz_0fu0kE,3:00f0f_3FcYHnaPaErz_0fu0kE,3:00T0T_8ThhloJ57Woz_0fu0kE,3:00S0S_50vRwdaQRMFz_0fu0kE,3:01313_4Wt6rNk3E3jz_0fu0kE,3:00y0y_5XAsm8Me9bjz_0fu0kE,3:01717_7G7Dn5z1Zgtz_0fu0kE,3:01010_882yhVh5U4Zz_0b20eI,3:00g0g_8vU8VowTsQMz_0b20eI,3:00O0O_iFsIAfLyjglz_0b20eI,3:00H0H_YeEPiFICDsz_0b20eI,3:00C0C_h3pt5e8CEJez_0b20eI,3:00J0J_evRdbQmEhUzz_0b20eI,3:00I0I_9jLZZogyspaz_0fu0kE,3:00909_cuFM12nMFNmz_0b20eI,3:00g0g_5lgT2Bs4fhUz_0b20eI,3:00X0X_lPND4ZSZFyez_0b20eI,3:00d0d_fgy8XadbhAyz_0ak07K">
+                <span class="result-price">$3,800</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6000px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00505_2gIeHjSuhakz_0ak07K_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 20</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:15" title="Thu 25 Feb 05:15:02 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-custom-build-bed-bath-den/7282931465.html" data-id="7282931465" class="result-title hdrlnk" id="postid_7282931465">Custom build 4 Bed 3 Bath + Den @East 64 Ave &amp; Victoria Dr</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$3,800</span>
+
+                <span class="housing">
+                    4br -
+                    2700ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (East 64th Ave Vancouver / Fraserview)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7273750709">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-new-bright-1bd-flex-in-heart/7273750709.html" class="result-image gallery" data-ids="3:00i0i_jKm1JtEr95xz_0CI0t2,3:00707_jsXDjG9vngyz_0t20CI,3:00X0X_7vDdpKjE1DPz_0t20CI,3:00i0i_jKm1JtEr95xz_0CI0t2,3:00606_clNME2IDNqtz_0t20CI,3:00A0A_8oieMz91rNcz_0t20CI,3:01212_ckXTt2kqYgpz_0t20CI,3:00T0T_eYKXwOk6owyz_0t20CI,3:01717_4WtO2W8DETuz_0t20CI,3:01010_kbubjFQjtjjz_0t20CI,3:00k0k_9dJymUYomoxz_0t20CI,3:00f0f_gMTwsyQKr4sz_0t20CI,3:00y0y_5EhiWuOWFaz_0t20CI,3:00L0L_78YER7KtkCRz_0t20CI,3:00T0T_93g0oXTmJAWz_0CI0t2,3:00808_drD9vJr5M8lz_0t20CI,3:00E0E_2Py0Dxw2fdgz_0t20CI,3:00J0J_6JOJ359PFP1z_0t20CI,3:00L0L_42cksUdLVJz_0t20CI,3:00G0G_2JFe1qrxWGXz_0t20CI,3:00N0N_didCRZxZQa7z_0CI0t2,3:00L0L_6Yej64mzUwez_0dm0h0">
+                <span class="result-price">$2,200</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6600px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00i0i_jKm1JtEr95xz_0CI0t2_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="20" style="width: 300px; left: -6000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="21" style="width: 300px; left: -6300px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 22</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:14" title="Thu 25 Feb 05:14:22 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-new-bright-1bd-flex-in-heart/7273750709.html" data-id="7273750709" class="result-title hdrlnk" id="postid_7273750709">New &amp; Bright 1bd + flex in heart of Kits!</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,200</span>
+
+                <span class="housing">
+                    1br -
+                    656ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Kitsilano)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7280022737">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7280022737.html" class="result-image gallery" data-ids="3:00p0p_97DXIesNA9sz_0kE0fu,3:00505_3yutevaV4s9z_0kE0fu,3:00X0X_avjEsijam4Fz_04Q03D,3:00a0a_6jElcaBHGhiz_0jm0ew,3:00r0r_ccjLCjx2AChz_05r07g,3:00404_fZD6yNXuAPnz_0jm0ew,3:00000_easW3X6RqBgz_09G07g,3:00a0a_gjK5D1WhaLzz_05r07g,3:00D0D_3hb3aCXnshIz_05r07g,3:00Y0Y_hWKUj9z6CsKz_05r07g,3:01414_9PvNO7DmKWzz_09G07g,3:00K0K_Miv6poPWHJz_09G07g,3:00202_36RQGzuRTtGz_03904c,3:00k0k_6hjNWBqUbZTz_03904c,3:00L0L_6XtmlfNf2vOz_03904c,3:00O0O_dkafMaXOUtBz_04c039,3:00d0d_gQKRXAQUUpjz_03904c">
+                <span class="result-price">$1,635</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5100px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00p0p_97DXIesNA9sz_0kE0fu_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 17</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:14" title="Thu 25 Feb 05:14:00 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7280022737.html" data-id="7280022737" class="result-title hdrlnk" id="postid_7280022737">One Bedroom Apartment/Cambie Village</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,635</span>
+
+                <span class="housing">
+                    1br -
+                    750ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7278570705">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7278570705.html" class="result-image gallery" data-ids="3:00p0p_97DXIesNA9sz_0kE0fu,3:00B0B_53d7sgvPOgVz_04c039,3:00E0E_gZQvc6pQsRjz_04c039,3:00808_bog9e2Jlqpz_04c039,3:00e0e_asldzvL5aNoz_03904c,3:00p0p_4jsiFvbAjvzz_03904c,3:00u0u_5cwTxhuyHWDz_04c039,3:00U0U_hFYn3hijW5z_04c039,3:00m0m_jhyvRcjMzEIz_04c039,3:00d0d_j7sTKCdKXzRz_03904c,3:00a0a_appXI5XoHQqz_03904c,3:00E0E_7qos1s8oJ4Zz_03904c,3:00t0t_6xVP5PgAz32z_04c039,3:00P0P_nFmuAfZJqBz_04c039,3:00m0m_jhyvRcjMzEIz_04c039">
+                <span class="result-price">$1,635</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4500px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00p0p_97DXIesNA9sz_0kE0fu_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 15</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:13" title="Thu 25 Feb 05:13:58 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-cambie/7278570705.html" data-id="7278570705" class="result-title hdrlnk" id="postid_7278570705">One Bedroom Apartment/Cambie Village</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,635</span>
+
+                <span class="housing">
+                    1br -
+                    750ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282930906" data-repost-of="7269111581">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-level-bedroom-plus-den-25/7282930906.html" class="result-image gallery" data-ids="3:00e0e_1G6SNYjLbiLz_0jm0cU,3:00m0m_2a56SJfzveLz_0jm0cU,3:00n0n_4wJOtTx2ntxz_0jm0cU,3:00u0u_6VPuG86Stnuz_0jm0cU,3:00E0E_j68UWTt5PoWz_0jm0cU,3:00T0T_eyqELNqyy0fz_0jm0cU,3:00K0K_dAgdpEuGt4Iz_0jm0cU,3:00W0W_5ak5WmwdBirz_0jm0cU,3:01717_kQQDrY8yGdGz_0jm0cU,3:01515_lCzVf4sojN9z_0i90bU,3:00L0L_b9siuoC4h11z_0aT0ew,3:01111_4ZydbLwoE1Kz_0jm0cU,3:00K0K_fye8EVUaAbsz_0jm0ew,3:00J0J_99CoWeDqQsDz_0jm0cU,3:01717_hUpDQnDrD8dz_0jm0cU,3:01111_9g3qZnWuxjBz_0jm0cU,3:01414_gRgI8GJaWktz_0jm0cU,3:00L0L_3inOUBOVFDez_0jm0cQ,3:00p0p_gmWsbcDzPkKz_0jm0cU,3:00303_l9BciAEXTBNz_09G07g">
+                <span class="result-price">$5,495</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 6000px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00e0e_1G6SNYjLbiLz_0jm0cU_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="18" style="width: 300px; left: -5400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="19" style="width: 300px; left: -5700px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 20</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:13" title="Thu 25 Feb 05:13:30 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-level-bedroom-plus-den-25/7282930906.html" data-id="7282930906" class="result-title hdrlnk" id="postid_7282930906">Level, 2 Bedroom plus Den, 2.5 Bathroom with Private Rooftop Patio</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$5,495</span>
+
+                <span class="housing">
+                    2br -
+                    1200ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (Tinseltown-Crosstown)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282930799">
+
+        <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-outer-northwest-bdrm-suite/7282930799.html" class="result-image gallery empty" title="no image"></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:13" title="Thu 25 Feb 05:13:13 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rds/apa/d/surrey-outer-northwest-bdrm-suite/7282930799.html" data-id="7282930799" class="result-title hdrlnk" id="postid_7282930799">2 bdrm suite</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,500</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (Surrey)</span>
+
+                <span class="result-tags">
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7278569319">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7278569319.html" class="result-image gallery" data-ids="3:00F0F_eO413sZCZGgz_0kE0fu,3:00000_ZGDBfEuZpoz_04507g,3:01616_7RJS8QtX1E3z_0aT0ew,3:00909_hwugnUg2rRgz_04507g,3:00Q0Q_kKEKVfOx8yFz_0jm0ew,3:00G0G_i9gGXNXhveRz_05r07g,3:01616_fqq1vpHo2Ubz_09G07g,3:00W0W_kiEoG98Odimz_0lM0t2,3:00I0I_3xAxJw7NQvTz_0CI0t2,3:00C0C_jTj3Gs9ptwwz_0lM0t2,3:01515_biF1kY1I7D8z_0lM0t2,3:00U0U_Q0zNcbvOD6z_0CI0t2,3:00909_kpTxjTGR5aWz_0lM0t2,3:00n0n_gN7oJvdcgkWz_0fu0kE,3:01616_hjN8TeOJUvHz_0lM0t2,3:00000_ftWyyLklAOdz_0lM0t2,3:00z0z_k4rcIGPQTmzz_0CI0t2,3:00u0u_7Cglv8txsP0z_0CI0t2">
+                <span class="result-price">$1,595</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 5400px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00F0F_eO413sZCZGgz_0kE0fu_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="14" style="width: 300px; left: -4200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="15" style="width: 300px; left: -4500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="16" style="width: 300px; left: -4800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="17" style="width: 300px; left: -5100px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 18</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:12" title="Thu 25 Feb 05:12:56 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-one-bedroom-apartment-balcony/7278569319.html" data-id="7278569319" class="result-title hdrlnk" id="postid_7278569319">One Bedroom Apartment/Balcony/West End</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$1,595</span>
+
+                <span class="housing">
+                    1br -
+                    550ft<sup>2</sup> -
+                </span>
+
+                <span class="result-hood"> (VANCOUVER)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7279242500" data-repost-of="7261635716">
+
+        <a href="https://vancouver.craigslist.org/rch/apa/d/richmond-richmond-unfurnished-br-hi/7279242500.html" class="result-image gallery" data-ids="3:00101_2R7Ym1JeUuWz_0ak06S,3:00202_1PrjxE14Rblz_0ak076,3:01717_10ko55kAIZVz_0ak06S,3:00B0B_b2RAxCdTwMKz_0ak06S,3:00000_5nmUZu0o6Tbz_0ak06S,3:00C0C_g3xsyHRDWB4z_0ak06S,3:00K0K_9yrYcRvrd9Nz_0ak06S,3:01111_i8mPGhMbZXSz_0ak06S,3:00y0y_ahEgb0FpVwSz_0ak06S,3:00p0p_jLLmNke8P4xz_0ak06S,3:00X0X_4EroeyCTKEFz_0ak06S,3:00I0I_fP8YVhyrE97z_0ak06S,3:00z0z_2Q19HedTX3Mz_0ak06U,3:01414_eaOGogc1pEBz_0ak06W">
+                <span class="result-price">$2,180</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 4200px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00101_2R7Ym1JeUuWz_0ak06S_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="6" style="width: 300px; left: -1800px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="7" style="width: 300px; left: -2100px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="8" style="width: 300px; left: -2400px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="9" style="width: 300px; left: -2700px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="10" style="width: 300px; left: -3000px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="11" style="width: 300px; left: -3300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="12" style="width: 300px; left: -3600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="13" style="width: 300px; left: -3900px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 14</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:12" title="Thu 25 Feb 05:12:51 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/rch/apa/d/richmond-richmond-unfurnished-br-hi/7279242500.html" data-id="7279242500" class="result-title hdrlnk" id="postid_7279242500">Richmond Unfurnished 2 BR Hi-Rise Apt for $2180/m</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,180</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (7888 Saba Road, Richmond)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+         <li class="result-row" data-pid="7282925649" data-repost-of="7277620832">
+
+        <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautifully-furnished/7282925649.html" class="result-image gallery" data-ids="3:00f0f_4FsPBMy69Frz_0fu0ak,3:00R0R_l1zUtHuGSNmz_0fu0aj,3:00e0e_7EaWAPtxQLiz_0fu0bC,3:00909_5BGzo6e1Gd2z_0fu0aj,3:01111_oVegOshUoYz_0fu0aj,3:01313_3xXc3w8OBeUz_0fu0aj">
+                <span class="result-price">$2,960</span>
+        <div class="swipe" style="visibility: visible;"><div class="swipe-wrap" style="width: 1800px;"><div data-index="0" style="width: 300px; left: 0px; transition-duration: 0ms; transform: translate(0px, 0px);"><img alt="" class="" src="./vancouver, BC apartments _ housing for rent - craigslist_files/00f0f_4FsPBMy69Frz_0fu0ak_300x300.jpg"></div><div data-index="1" style="width: 300px; left: -300px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="2" style="width: 300px; left: -600px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="3" style="width: 300px; left: -900px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="4" style="width: 300px; left: -1200px; transition-duration: 0ms; transform: translate(300px, 0px);"></div><div data-index="5" style="width: 300px; left: -1500px; transition-duration: 0ms; transform: translate(-300px, 0px);"></div></div></div><div class="slider-info">image 1 of 6</div><div class="slider-back arrow">&lt;</div><div class="slider-forward arrow">&gt;</div></a>
+
+    <div class="result-info">
+        <span class="icon icon-star" role="button" title="save this post in your favorites list">
+            <span class="screen-reader-text">favorite this post</span>
+        </span>
+
+            <time class="result-date" datetime="2021-02-25 17:12" title="Thu 25 Feb 05:12:50 PM">Feb 25</time>
+
+
+        <h3 class="result-heading">
+            <a href="https://vancouver.craigslist.org/van/apa/d/vancouver-beautifully-furnished/7282925649.html" data-id="7282925649" class="result-title hdrlnk" id="postid_7282925649">Beautifully furnished 2 bedrooms 1 bathroom apartment in the heart of</a>
+        </h3>
+
+
+        <span class="result-meta">
+                <span class="result-price">$2,960</span>
+
+                <span class="housing">
+                    2br -
+                </span>
+
+                <span class="result-hood"> (downtown Vancouver)</span>
+
+                <span class="result-tags">
+                    <span class="pictag">pic</span>
+                </span>
+
+                <span class="banish icon icon-trash" role="button">
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+
+            <span class="unbanish icon icon-trash red" role="button" aria-hidden="true"></span>
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#" class="restore-link">
+                <span class="restore-narrow-text">restore</span>
+                <span class="restore-wide-text">restore this posting</span>
+            </a>
+
+        </span>
+    </div>
+</li>
+
+                    
+                    
+                </ul>
+            </div>
+
+            <div class="search-legend bottom">
+                <div class="search-view">
+                    <span class="buttongroup"><a class="backtotop button" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#page-top">^ back to top</a></span>
+                </div>
+                <div class="search-sort">
+                    <span class="buttongroup"><a class="backtotop button" href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa#page-top">^ back to top</a></span>
+                </div>
+                <div class="paginator buttongroup firstpage">
+    <span class="resulttotal">
+        <span class="for-map">
+        showing <span class="displaycountShow">...</span> postings
+        <span class="zoom-out-for-more" style="display: none">
+            -
+            <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa">
+                zoom out for all <span class="total">3000</span>
+            </a>
+        </span>
+
+        </span>
+    </span>
+    <span class="buttons">
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" class="button first" title="first page">&lt;&lt;</a>
+        <span class="button first" title="first page">&lt;&lt;</span>
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa" class="button prev" title="previous page">&lt; prev</a>
+        <span class="button prev" title="previous page">&lt; prev</span>
+
+        <span class="button pagenum">
+            <span class="range">
+                <span class="rangeFrom">1</span>
+                -
+                <span class="rangeTo">120</span>
+            </span>
+            /
+            <span class="totalcount">3000</span>
+        </span>
+
+        <a href="https://vancouver.craigslist.org/d/apartments-housing-for-rent/search/apa?s=120" class="button next" title="next page">next &gt; </a>
+        <span class="button next" title="next page"> next &gt; </span>
+    </span>
+</div>
+
+            </div>
+
+            <section class="blurbs">
+                
+            </section>
+
+            <div id="floater" style="display: none;">
+                <img class="loading" src="./vancouver, BC apartments _ housing for rent - craigslist_files/animated-spinny.gif" alt="">
+                <img class="payload" src="./vancouver, BC apartments _ housing for rent - craigslist_files/animated-spinny.gif" alt="">
+            </div>
+        </form>
+
+<aside class="tsb">
+    <ul>
+        <li><a href="https://www.craigslist.org/about/FHA">fair housing</a>
+        </li><li><a href="https://www.craigslist.org/about/scams">avoiding scams</a>
+    </li></ul>
+</aside>
+
+<div class="slidemessage">
+    <span class="fave">
+        <span class="star"></span>
+        favorited
+    </span>
+    <span class="unfave">
+        <span class="star"></span>
+        no longer favorited
+    </span>
+    <span class="hide">
+        <span class="trash"></span>
+        hidden
+    </span>
+    <span class="unhide">
+        <span class="trash"></span>
+        no longer hidden
+    </span>
+</div>
+
+<footer>
+    <ul class="clfooter">
+        <li>© 2021 <span class="desktop">craigslist</span><span class="mobile">CL</span></li>
+        <li><a href="https://www.craigslist.org/about/help/">help</a></li>
+        <li><a href="https://www.craigslist.org/about/scams">safety</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/privacy.policy">privacy</a><sup class="neu">new</sup></li>
+        <li class="desktop"><a href="https://forums.craigslist.org/?forumID=8">feedback</a></li>
+        <li><a href="https://www.craigslist.org/about/terms.of.use">terms</a></li>
+        <li><a href="https://www.craigslist.org/about/">about</a></li>
+        <li class="fsel desktop linklike" data-mode="mobile">mobile</li>
+        <li class="fsel mobile linklike" data-mode="regular">desktop</li>
+    </ul>
+</footer>
+    </section>
+
+    <template id="gallerycarousel"></template>
+
+    
+                <script>
+                try {
+                    if (
+                        !/\/\/.+\.craigslist\.org\/about\//.test(window.location.href)
+                        &&
+                        (!window.addEventListener || JSON.parse(JSON.stringify('x')) !== 'x')
+                    ) {
+                        throw "unsupported browser";
+                    }
+                } catch (e) {
+                    function cleanup() {
+                        document.body.innerHTML = '<div id="cl-unsupported-browser" style="margin:1em;font-size:150%;text-align:center;">We have detected you are using a browser that is missing critical features.<br><br>Please visit craigslist from a modern browser.</div>';
+                        document.body.style = "display:block";
+                    }
+
+                    try {
+                        document.body.style = "display:none";
+                    } catch (e) {
+                    }
+                    window.onload = cleanup;
+                    window.clUnsupportedBrowser = true;
+                }
+                </script>
+            <script src="./vancouver, BC apartments _ housing for rent - craigslist_files/general-concat.min.js.download" type="text/javascript"></script>
+
+<script type="text/template" id="clustertemplate">
+    <li class="posting {visited}" data-pid="{PostingID}">
+        <img src="{ImageThumb}">
+        <div class="housing_bubble_banner">
+            <span class="{hasPrice}price">{currencySymbol}{price}</span>
+            <span class="bedrooms">{BedroomsContent}</span>
+            <span class="postingtitle"><a>{PostingTitle}</a></span>
+            <span class="js-only map-banish-unbanish" data-pid="{PostingID}">
+                <span class="banish">
+                    <span class="icon icon-trash" role="button"></span>
+                    <span class="screen-reader-text">hide this posting</span>
+                </span>
+                <span class="unbanish">
+                    <span class="icon icon-trash red" role="button"></span>
+                    unhide
+                </span>
+            </span>
+        </div>
+    </li>
+</script>
+<script type="text/template" id="postingtemplate">
+    <div class="viewcontainer pics loading">
+        <div class="backtolist">
+            &laquo; back to posting list
+        </div>
+        <div class="title">
+            <span class="icon icon-star" data-pid="{PostingID}" role="button">
+                <span class="screen-reader-text">favorite this post</span>
+            </span>
+            <span class="postingtitle">
+                <a href="{PostingURL}" target="_blank">{PostingTitle}</a>
+            </span>
+            <div>
+                <span class="{hasPrice}price">{currencySymbol}{price}</span>
+                <span class="bedrooms">{BedroomsContent}</span>
+                <span class="js-only map-banish-unbanish" data-pid="{PostingID}">
+                    <span class="banish">
+                        <span class="icon icon-trash" role="button"></span>
+                        <span class="screen-reader-text">hide this posting</span>
+                    </span>
+                    <span class="unbanish">
+                        <span class="icon icon-trash red" role="button"></span>
+                        <span class="screen-reader-text">unhide</span>
+                        unhide
+                    </span>
+                </span>
+            </div>
+        </div>
+        <hr style="clear:both">
+        <div class="picscontainer gallery">
+            <span class="slider-back arrow">&lt;</span><span class="slider-info"></span><span class="slider-forward arrow">&gt;</span>
+            <div class="swipe">
+                <div class="swipe-wrap">
+                    <img class="loading" src="//www.craigslist.org/images/animated-spinny.gif" alt="">
+                </div>
+            </div>
+        </div>
+        <div class="infocontainer"></div>
+        <hr style="clear:both">
+        <div class="timecontainer"></div>
+        <a class="viewpostinglink" href="{PostingURL}" target="_blank">view posting</a>
+        <div class="contenttoggle">
+            <a class="moreinfo">more info</a>
+            <a class="showpics">show images</a>
+        </div>
+    </div>
+</script>
+<script type="text/template" id="popuptemplate">
+    <div id="mapbubble" class="posting">
+        <ul id="clusterbubble"></ul>
+        <div id="postbubble"></div>
+    </div>
+</script>
+    <script src="./vancouver, BC apartments _ housing for rent - craigslist_files/leaflet-concat.min.js.download" type="text/javascript"></script>
+
+    <script src="./vancouver, BC apartments _ housing for rent - craigslist_files/search-concat.min.js.download" type="text/javascript"></script><ul class="ui-autocomplete ui-front ui-menu ui-widget ui-widget-content" id="ui-id-1" tabindex="0" style="display: none;"></ul><span role="status" aria-live="assertive" aria-relevant="additions" class="ui-helper-hidden-accessible"></span>
+
+    <script src="./vancouver, BC apartments _ housing for rent - craigslist_files/postings-concat.min.js.download" type="text/javascript"></script>
+
+
+
+<iframe src="./vancouver, BC apartments _ housing for rent - craigslist_files/localStorage-b2c30773fe82c3d5e475613ad0f725fa9ab277fb.html" style="display: none;"></iframe></body></html>


### PR DESCRIPTION
* I added scraper.py with full docstring. The script can download data from https://vancouver.craigslist.org/search/van/apa and generate a raw.csv containing listing information like price, house type and neighborhood. `raw.csv` should be in root folder when you run the script with the following command at root folder:
 ```
python pyhousehunter/scraper.py --url=https://vancouver.craigslist.org/search/van/apa
```

* This is of course still a working-in-progress. I will explore how to scrape multiple pages at the same time next week:). However, I think @JuntingHe  and @elina-linglin can work on `raw.csv` for subsequent tasks.
* I added `househunt.yaml` to create the virtual environment to run `scaper.py`
*  I also included `van_housing_listings.html` in `temp` folder for local test first.

